### PR TITLE
Avoid setting CMAKE_CXX_COMPILER

### DIFF
--- a/clients/examples/CMakeLists.txt
+++ b/clients/examples/CMakeLists.txt
@@ -27,7 +27,6 @@ cmake_minimum_required(VERSION 3.16.3 FATAL_ERROR)
 ###############################################################################
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_COMPILER /opt/rocm/bin/hipcc)
 set(CMAKE_CXX_FLAGS_DEBUG "-O0 -ggdb")
 
 ###############################################################################

--- a/clients/sos-tests/CMakeLists.txt
+++ b/clients/sos-tests/CMakeLists.txt
@@ -27,7 +27,6 @@ cmake_minimum_required(VERSION 3.16.3 FATAL_ERROR)
 ###############################################################################
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_COMPILER /opt/rocm/bin/hipcc)
 set(CMAKE_CXX_FLAGS_DEBUG "-O0 -ggdb")
 
 ###############################################################################

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -27,7 +27,6 @@ cmake_minimum_required(VERSION 3.16.3 FATAL_ERROR)
 ###############################################################################
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_COMPILER /opt/rocm/bin/hipcc)
 set(CMAKE_CXX_FLAGS_DEBUG "-O0 -ggdb")
 
 ###############################################################################


### PR DESCRIPTION
Avoid overriding CMAKE_CXX_COMPILER by setting it as the preset path rarely matches installations