### PR TITLE
Fix signal calculation bug for fine-tiled unit tests

### DIFF
--- a/tests/unit_tests/ipc_impl_tiled_fine_gtest.cpp
+++ b/tests/unit_tests/ipc_impl_tiled_fine_gtest.cpp
@@ -141,7 +141,7 @@ int warp_signals_calculation(int grid_dim_x, int block_dim_x, size_t size) {
 
     int warps_per_block {warpsPerBlock(block_dim_x)};
     int total_num_warps_in_grid {grid_dim_x * warps_per_block};
-    int bytes_per_warp {WARP_SIZE * THREAD_TRANSFER_GRANULARITY};
+    int bytes_per_warp {min(block_dim_x, WARP_SIZE) * THREAD_TRANSFER_GRANULARITY};
 
     int num_signals_for_one_full_iteration = total_num_warps_in_grid;
     int num_signals_for_partial_last_iteration = ((partial_grid_last_iteration_data_size - THREAD_TRANSFER_GRANULARITY) + bytes_per_warp) / bytes_per_warp;

--- a/tests/unit_tests/ipc_impl_tiled_fine_gtest.hpp
+++ b/tests/unit_tests/ipc_impl_tiled_fine_gtest.hpp
@@ -257,6 +257,7 @@ class IPCImplTiledFine : public ::testing::TestWithParam<std::tuple<int, int, in
                 int *dest = reinterpret_cast<int*>(ipc_impl_.ipc_bases[1]);
                 FN_T2 val_fn = kernel_put_with_signal_tiled_validator;
                 launch(val_fn, grid, block, dest, bytes);
+                ASSERT_EQ(*(dest + SIGNAL_OFFSET), 0);
             }
             mpi_.barrier();
             return;


### PR DESCRIPTION
The signal values were underflowing their target count due to a miscalculation in the host-side initialization.  Also added a host-side ASSERT_EQ check to prevent this from silently happening again.