### PR TITLE
Commented function that fails functional tests

### DIFF
--- a/tests/functional_tests/tester.cpp
+++ b/tests/functional_tests/tester.cpp
@@ -518,7 +518,7 @@ void Tester::execute() {
       }
 
       //            rocshmem_dump_stats();
-      rocshmem_reset_stats();
+      // rocshmem_reset_stats();
     }
 
     barrier();


### PR DESCRIPTION
- This call is not implemented by the IPC backend (calls `assert(false)`)
- Fails when running functional tests
- Not sure why is only occurs with ROCm 6.4 and didn't occur before...