### PR TITLE
Fix `rocshmem_team_split_strided` API

### DIFF
--- a/src/rocshmem.cpp
+++ b/src/rocshmem.cpp
@@ -229,7 +229,8 @@ __host__ int rocshmem_team_split_strided(
   auto num_user_teams{backend->team_tracker.get_num_user_teams()};
   auto max_num_teams{backend->team_tracker.get_max_num_teams()};
   if (num_user_teams >= max_num_teams - 1) {
-    abort();
+    /* Exceeded maximum number of teams */
+    return -1;
   }
 
   if (parent_team == ROCSHMEM_TEAM_INVALID) {

--- a/tests/functional_tests/tester.cpp
+++ b/tests/functional_tests/tester.cpp
@@ -570,7 +570,7 @@ bool Tester::peLaunchesKernel() {
    * Some test types are active on both sides.
    */
   is_launcher = is_launcher || (_type == TeamReductionTestType) ||
-                (_type == TeamBroadcastTestType) ||
+                (_type == TeamBroadcastTestType) || (_type == TeamCtxInfraTestType) ||
                 (_type == AllToAllTestType) || (_type == FCollectTestType) ||
                 (_type == PingPongTestType) || (_type == BarrierAllTestType) ||
                 (_type == SyncTestType) || (_type == SyncAllTestType) ||


### PR DESCRIPTION
Updated `rocshmem_team_split_strided` API to return non-zero value when the number of teams exceeds the maximum limit.