### PR TITLE
IPC backend now aborts with rocshmem_global_exit()

### DIFF
--- a/src/ipc/backend_ipc.cpp
+++ b/src/ipc/backend_ipc.cpp
@@ -286,7 +286,7 @@ void IPCBackend::initIPC() {
 }
 
 void IPCBackend::global_exit(int status) {
-  assert(false);
+  MPI_Abort(MPI_COMM_WORLD, status);
 }
 
 void IPCBackend::teams_destroy() {


### PR DESCRIPTION
Currently `rocshmem_global_exit()` does not exit the program for the IPC conduit.

For example, `ROCSHMEM_HEAP_SIZE=1024 ROCSHMEM_MAX_NUM_CONTEXTS=2 mpirun -np 8 ./rocshmem_allreduce_test` segfaults rather than exits cleanly as the code should.

This PR now aborts the program when exit is called

