### PR TITLE
Automatic Memory Management with `shared_ptr` for host interface

### DIFF
--- a/src/ipc/backend_ipc.cpp
+++ b/src/ipc/backend_ipc.cpp
@@ -77,8 +77,9 @@ IPCBackend::IPCBackend(MPI_Comm comm)
   bp->heap_ptr = &heap;
 
   /* Initialize the host interface */
-  host_interface =
-      new HostInterface(hdp_proxy_.get(), thread_comm, &heap);
+  host_interface = std::make_shared<HostInterface>(hdp_proxy_.get(),
+                                                 thread_comm,
+                                                 &heap);
 
   default_host_ctx = std::make_unique<IPCHostContext>(this, 0);
 
@@ -116,11 +117,6 @@ IPCBackend::~IPCBackend() {
    * Free the atomic_ret array.
    */
   CHECK_HIP(hipFree(bp->atomic_ret->atomic_base_ptr));
-
-  // TODO(Avinash) Free g_ret
-
-  // delete host_interface;
-  // host_interface = nullptr;
 
   /**
    * Destroy teams infrastructure

--- a/src/ipc/backend_ipc.hpp
+++ b/src/ipc/backend_ipc.hpp
@@ -124,9 +124,9 @@ class IPCBackend : public Backend {
 
   /**
    * @brief The host-facing interface that will be used
-   * by all contexts of the ROBackend
+   * by all contexts of the IPCBackend
    */
-  HostInterface *host_interface{nullptr};
+  std::shared_ptr<HostInterface> host_interface{nullptr};
 
   /**
    * @brief Scratchpad for the internal barrier algorithms.

--- a/src/ipc/context_ipc_host.hpp
+++ b/src/ipc/context_ipc_host.hpp
@@ -136,8 +136,8 @@ class IPCHostContext : public Context {
   __host__ int test(T *ivars, int cmp, T val);
 
  public:
-  /* Pointer to the backend's host interface */
-  HostInterface *host_interface{nullptr};
+  /* Shared pointer to the backend's host interface */
+  std::shared_ptr<HostInterface> host_interface{nullptr};
 
   /* An MPI Window implements a context */
   WindowInfo *context_window_info{nullptr};


### PR DESCRIPTION
Changed the `host interface` to use automatic memory allocation instead of explicit allocation. This ensures the `default host context` to securely release resources before the host interface is destroyed. Previously, the host interface was dynamically created, making it the first to be destroyed by the class destructor, followed by the destruction of the class's non-static members, in accordance with C++ rules, preventing the default host context from safely releasing its resources.