### PR TITLE
Add `BUILD_EXAMPLES` CMake option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,7 @@ option(USE_SHARED_CTX "Request support for shared ctx between WG" OFF)
 option(USE_SINGLE_NODE "Enable single node support only." OFF)
 option(USE_HOST_SIDE_HDP_FLUSH "Use a polling thread to flush the HDP cache on the host." OFF)
 option(BUILD_FUNCTIONAL_TESTS "Build the functional tests" ON)
+option(BUILD_EXAMPLES "Build the examples" ON)
 option(BUILD_SOS_TESTS "Build the host-facing tests" OFF)
 option(BUILD_UNIT_TESTS "Build the unit tests" ON)
 option(BUILD_LOCAL_GPU_TARGET_ONLY "Build only for GPUs detected on this machine" OFF)
@@ -152,7 +153,10 @@ target_include_directories(
 ###############################################################################
 add_subdirectory(src)
 add_subdirectory(tests)
-add_subdirectory(examples)
+
+IF (BUILD_EXAMPLES)
+  add_subdirectory(examples)
+ENDIF()
 
 ###############################################################################
 # HIP


### PR DESCRIPTION
This PR proposes adding the `BUILD_EXAMPLES` CMake option, aligning with existing `BUILD_*` flags. This addition allows users to disable example builds when only the library is needed, reducing unnecessary build time. Default is set to `ON` to match current behavior.