### PR TITLE
Generate CMake Package Configuration Files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -252,6 +252,11 @@ rocm_package_add_dependencies(
     rocm-dev
 )
 
+rocm_export_targets(
+  TARGETS roc::rocshmem
+  NAMESPACE roc::
+)
+
 rocm_create_package(
   NAME "rocSHMEM"
   DESCRIPTION "ROCm OpenSHMEM (rocSHMEM)"


### PR DESCRIPTION
- This PR adds functionality to generate CMake package configuration files
- Resolves issue: 
  - #26 
- This makes it easier for users to add rocSHMEM to their projects. e.g:
```
find_package(rocshmem REQUIRED)
target_link_libraries(
    ${EXECUTABLE_NAME}
    PRIVATE
      roc::rocshmem
)
```