### PR TITLE
Update(`DeviceProxy`): Dynamically Determine Memory Allocation Size & Remove Compile-Time size Calculations

### DIFF
--- a/src/containers/forward_list.hpp
+++ b/src/containers/forward_list.hpp
@@ -486,9 +486,19 @@ std::string to_string(const ForwardList<TYPE, ALLOC>& list);
 
 template <typename ALLOC, typename TYPE>
 class ForwardListProxy {
-  using ProxyT = DeviceProxy<ALLOC, ForwardList<TYPE, ALLOC>, 1>;
+  using ProxyT = DeviceProxy<ALLOC, ForwardList<TYPE, ALLOC>>;
 
  public:
+  ForwardList(size_t num_elems = 1) : proxy_{num_elems} {}
+
+  ForwardList(const ForwardList& other) = delete;
+
+  ForwardList& operator=(const ForwardList& other) = delete;
+
+  ForwardList(ForwardList&& other) = default;
+
+  ForwardList& operator=(ForwardList&& other) = default;
+
   __host__ __device__ ForwardList<TYPE, ALLOC>* get() { return proxy_.get(); }
 
  private:

--- a/src/containers/free_list.hpp
+++ b/src/containers/free_list.hpp
@@ -262,7 +262,17 @@ class FreeListProxy {
  public:
   __host__ __device__ FreeListT* get() { return proxy_.get(); }
 
-  FreeListProxy() { new (proxy_.get()) FreeListT(); }
+  FreeListProxy(size_t num_elems = 1) : proxy_{num_elems} {
+    new (proxy_.get()) FreeListT();
+  }
+
+  FreeListProxy(const FreeListProxy& other) = delete;
+
+  FreeListProxy& operator=(const FreeListProxy& other) = delete;
+
+  FreeListProxy(FreeListProxy&& other) = default;
+
+  FreeListProxy& operator=(FreeListProxy&& other) = default;
 
   ~FreeListProxy() {
     auto free_list = proxy_.get();

--- a/src/device_proxy.hpp
+++ b/src/device_proxy.hpp
@@ -30,21 +30,28 @@
 
 namespace rocshmem {
 
-template <typename ALLOCATOR, typename T, size_t SIZE_IN = 1>
+template <typename ALLOCATOR, typename T>
 class DeviceProxy {
  public:
-  DeviceProxy() {
+  DeviceProxy() = default;
+
+  DeviceProxy(size_t num_elems) : num_elems_ {num_elems} {
+    /**
+     * @brief The allocation size of the internal memory
+     *
+    */
+    size_t size_bytes = sizeof(T) * num_elems_;
     /*
      * Allocate memory and verify that the allocation worked.
      */
     T* temp{nullptr};
-    allocator_.allocate(reinterpret_cast<void**>(&temp), SIZE_BYTES_);
+    allocator_.allocate(reinterpret_cast<void**>(&temp), size_bytes);
     assert(temp);
 
     /*
      * Default memory provided by the allocation to recognizable bytes.
      */
-    memset(static_cast<void*>(temp), 0xBC, SIZE_BYTES_);
+    memset(static_cast<void*>(temp), 0xBC, size_bytes);
 
     /*
      * Pass the memory into a unique ptr for tracking.
@@ -57,6 +64,14 @@ class DeviceProxy {
      */
     ptr_ = up_.get();
   }
+
+  DeviceProxy(const DeviceProxy& other) = delete;
+
+  DeviceProxy& operator=(const DeviceProxy& other) = delete;
+
+  DeviceProxy(DeviceProxy&& other) = default;
+
+  DeviceProxy& operator=(DeviceProxy&& other) = default;
 
   /**
    * @brief Return internal storage tracked by the Proxy.
@@ -98,9 +113,9 @@ class DeviceProxy {
   T* ptr_{nullptr};
 
   /**
-   * @brief The allocation size for the internal memory
+   * @brief Number of elements of type T to be allocated
    */
-  static constexpr size_t SIZE_BYTES_{sizeof(T) * SIZE_IN};
+  size_t num_elems_{};
 };
 
 }  // namespace rocshmem

--- a/src/hdp_proxy.hpp
+++ b/src/hdp_proxy.hpp
@@ -36,9 +36,17 @@ class HdpProxy {
   /*
    * Placement new the memory which is allocated by proxy_
    */
-  HdpProxy() {
+  HdpProxy(size_t num_elems = 1) : proxy_{num_elems} {
     new (proxy_.get()) HdpPolicy();
   }
+
+  HdpProxy(const HdpProxy& other) = delete;
+
+  HdpProxy& operator=(const HdpProxy& other) = delete;
+
+  HdpProxy(HdpProxy&& other) = default;
+
+  HdpProxy& operator=(HdpProxy&& other) = default;
 
   /*
    * Since placement new is called in the constructor, then

--- a/src/ipc/backend_ipc.cpp
+++ b/src/ipc/backend_ipc.cpp
@@ -221,7 +221,7 @@ void IPCBackend::create_new_team([[maybe_unused]] Team *parent_team,
 
   /**
    * Allocate device-side memory for team_world and
-   * construct a GPU_IB team in it
+   * construct a IPC team in it
    */
   GPUIBTeam *new_team_obj;
   CHECK_HIP(hipMalloc(&new_team_obj, sizeof(IPCTeam)));

--- a/src/ipc/ipc_context_proxy.hpp
+++ b/src/ipc/ipc_context_proxy.hpp
@@ -41,8 +41,9 @@ class IPCDefaultContextProxy {
   /*
    * Placement new the memory which is allocated by proxy_
    */
-  explicit IPCDefaultContextProxy(IPCBackend* backend, TeamInfo *tinfo)
-  : constructed_{true} {
+  explicit IPCDefaultContextProxy(IPCBackend* backend, TeamInfo *tinfo,
+                                  size_t num_elems = 1)
+  : constructed_{true}, proxy_{num_elems} {
     auto ctx{proxy_.get()};
     new (ctx) IPCContext(reinterpret_cast<Backend*>(backend));
     ctx->tinfo = tinfo;

--- a/src/memory/notifier.hpp
+++ b/src/memory/notifier.hpp
@@ -101,9 +101,17 @@ class NotifierProxy {
   using ProxyT = DeviceProxy<ALLOCATOR, Notifier<scope>>;
 
  public:
-  NotifierProxy() {
+  NotifierProxy(size_t num_elems = 1) : proxy_{num_elems} {
     new (proxy_.get()) Notifier<scope>();
   }
+
+  NotifierProxy(const NotifierProxy& other) = delete;
+
+  NotifierProxy& operator=(const NotifierProxy& other) = delete;
+
+  NotifierProxy(NotifierProxy&& other) = default;
+
+  NotifierProxy& operator=(NotifierProxy&& other) = default;
 
   ~NotifierProxy() {
     proxy_.get()->~Notifier<scope>();

--- a/src/memory/slab_heap.hpp
+++ b/src/memory/slab_heap.hpp
@@ -160,13 +160,23 @@ class SlabHeap {
 
 template <typename ALLOCATOR>
 class SlabHeapProxy {
-  using ProxyT = DeviceProxy<ALLOCATOR, SlabHeap, 1>;
+  using ProxyT = DeviceProxy<ALLOCATOR, SlabHeap>;
 
  public:
   /*
    * Placement new the memory which is allocated by proxy_
    */
-  SlabHeapProxy() { new (proxy_.get()) SlabHeap(); }
+  SlabHeapProxy(size_t num_elems = 1) : proxy_{num_elems} {
+    new (proxy_.get()) SlabHeap();
+  }
+
+  SlabHeapProxy(const SlabHeapProxy& other) = delete;
+
+  SlabHeapProxy& operator=(const SlabHeapProxy& other) = delete;
+
+  SlabHeapProxy(SlabHeapProxy&& other) = default;
+
+  SlabHeapProxy& operator=(SlabHeapProxy&& other) = default;
 
   /*
    * Since placement new is called in the constructor, then

--- a/src/reverse_offload/backend_proxy.hpp
+++ b/src/reverse_offload/backend_proxy.hpp
@@ -51,7 +51,9 @@ class BackendProxy {
   /*
    * Placement new the memory which is allocated by proxy_
    */
-  BackendProxy() { new (proxy_.get()) BackendRegister(); }
+  BackendProxy(size_t num_elems = 1) : proxy_{num_elems} {
+    new (proxy_.get()) BackendRegister();
+  }
 
   /*
    * Since placement new is called in the constructor, then

--- a/src/reverse_offload/backend_ro.hpp
+++ b/src/reverse_offload/backend_ro.hpp
@@ -255,6 +255,21 @@ class ROBackend : public Backend {
    * @brief Holds maximum number of contexts used in library
    */
   size_t maximum_num_contexts_{1024};
+
+  /**
+   * @brief Holds maximum threads per work-group
+  */
+  int max_wg_size_{};
+
+  /**
+   * @brief Holds the queue size for each context
+  */
+  size_t queue_size_{512};
+
+  /**
+   * @brief Number of MPI windows used for device contexts in RO Backend
+   */
+  size_t num_windows_{32};
 };
 
 }  // namespace rocshmem

--- a/src/reverse_offload/context_ro_device.cpp
+++ b/src/reverse_offload/context_ro_device.cpp
@@ -50,7 +50,7 @@ __host__ ROContext::ROContext(Backend *b, size_t block_id)
     auto block_base{backend->block_handle_proxy_.get()};
     block_handle = &block_base[block_id];
   }
-  ro_net_win_id = block_id % backend->ro_window_proxy_->MAX_NUM_WINDOWS;
+  ro_net_win_id = block_id % backend->ro_window_proxy_->get_num_MPI_windows();
 
   ipcImpl_.ipc_bases = b->ipcImpl.ipc_bases;
   ipcImpl_.shm_size = b->ipcImpl.shm_size;

--- a/src/reverse_offload/profiler.hpp
+++ b/src/reverse_offload/profiler.hpp
@@ -51,13 +51,13 @@ typedef NullStats<RO_NUM_STATS> ROStats;
 
 template <typename ALLOCATOR>
 class ProfilerProxy {
-  static constexpr size_t MAX_NUM_BLOCKS{65536};
-
-  using ProxyT = DeviceProxy<ALLOCATOR, ROStats, MAX_NUM_BLOCKS>;
+  using ProxyT = DeviceProxy<ALLOCATOR, ROStats>;
 
  public:
-  explicit ProfilerProxy(size_t num_blocks) : num_elem_{num_blocks} {
-    assert(num_blocks <= MAX_NUM_BLOCKS);
+  ProfilerProxy() = default;
+
+  explicit ProfilerProxy(size_t num_blocks)
+    : num_elem_{num_blocks}, proxy_{num_blocks} {
 
     auto *stat{proxy_.get()};
     assert(stat);
@@ -67,6 +67,14 @@ class ProfilerProxy {
       new (stat + i) ROStats();
     }
   }
+
+  ProfilerProxy(const ProfilerProxy& other) = delete;
+
+  ProfilerProxy& operator=(const ProfilerProxy& other) = delete;
+
+  ProfilerProxy(ProfilerProxy&& other) = default;
+
+  ProfilerProxy& operator=(ProfilerProxy&& other) = default;
 
   ~ProfilerProxy() {
     auto *stat{proxy_.get()};

--- a/src/reverse_offload/queue.cpp
+++ b/src/reverse_offload/queue.cpp
@@ -33,8 +33,22 @@ Queue::Queue() {
   }
 }
 
+Queue::Queue(size_t max_queues, size_t max_wg_size, size_t queue_size)
+    : max_queues_{max_queues},
+      max_wg_size_{max_wg_size},
+      queue_size_{queue_size},
+      queue_proxy_{max_queues, queue_size},
+      queue_desc_proxy_{max_queues, max_wg_size} {
+
+  gpu_queue = true;
+  char *value{nullptr};
+  if ((value = getenv("RO_NET_CPU_QUEUE")) != nullptr) {
+    gpu_queue = false;
+  }
+}
+
 uint64_t Queue::get_read_index(uint64_t queue_index) {
-  return descriptor(queue_index)->read_index % QUEUE_SIZE;
+  return descriptor(queue_index)->read_index % queue_size_;
 }
 
 void Queue::increment_read_index(uint64_t queue_index) {
@@ -92,7 +106,7 @@ void Queue::notify(int blockId, int threadId) {
 }
 
 uint64_t Queue::size() {
-  return QUEUE_SIZE;
+  return queue_size_;
 }
 
 __host__ __device__ queue_desc_t* Queue::descriptor(uint64_t index) {

--- a/src/reverse_offload/queue.hpp
+++ b/src/reverse_offload/queue.hpp
@@ -35,6 +35,8 @@ class Queue {
  public:
   Queue();
 
+  Queue(size_t max_queues, size_t max_threads_per_block, size_t queue_size);
+
   bool process(uint64_t queue_index, MPITransport* transport);
 
   uint64_t get_read_index(uint64_t queue_index);
@@ -67,6 +69,12 @@ class Queue {
   HdpProxy<HIPHostAllocator> hdp_proxy_{};
 
   bool gpu_queue{false};
+
+  size_t max_queues_{};
+
+  size_t max_wg_size_{};
+
+  size_t queue_size_{};
 };
 
 }  // namespace rocshmem

--- a/src/reverse_offload/queue_proxy.hpp
+++ b/src/reverse_offload/queue_proxy.hpp
@@ -35,7 +35,7 @@
 
 namespace rocshmem {
 
-constexpr size_t QUEUE_SIZE{512};
+// constexpr size_t QUEUE_SIZE{512};
 
 struct cacheline_t {
   volatile char valid;
@@ -82,7 +82,17 @@ class QueueElementProxy {
   using ProxyT = DeviceProxy<ALLOCATOR, queue_element_t>;
 
  public:
-  QueueElementProxy() { new (proxy_.get()) queue_element_t(); }
+  QueueElementProxy(size_t num_elems = 1) : proxy_{num_elems} {
+    new (proxy_.get()) queue_element_t();
+  }
+
+  QueueElementProxy(const QueueElementProxy& other) = delete;
+
+  QueueElementProxy& operator=(const QueueElementProxy& other) = delete;
+
+  QueueElementProxy(QueueElementProxy&& other) = default;
+
+  QueueElementProxy& operator=(QueueElementProxy&& other) = default;
 
   ~QueueElementProxy() { proxy_.get()->~queue_element_t(); }
 
@@ -96,11 +106,8 @@ using QueueElementProxyT = QueueElementProxy<PosixAligned64Allocator>;
 
 template <typename ALLOCATOR>
 class QueueProxy {
-  static constexpr size_t MAX_NUM_BLOCKS{65536};
-  static constexpr size_t TOTAL_QUEUE_ELEMENTS{QUEUE_SIZE * MAX_NUM_BLOCKS};
-  using ProxyT = DeviceProxy<ALLOCATOR, queue_element_t *, MAX_NUM_BLOCKS>;
-  using ProxyPerBlockT =
-      DeviceProxy<ALLOCATOR, queue_element_t, TOTAL_QUEUE_ELEMENTS>;
+  using ProxyT = DeviceProxy<ALLOCATOR, queue_element_t *>;
+  using ProxyPerBlockT = DeviceProxy<ALLOCATOR, queue_element_t>;
 
  public:
   /**
@@ -109,16 +116,31 @@ class QueueProxy {
    * The circular queues are indexed using the device block-id so that each
    * each block has its own queue.
    */
-  QueueProxy() {
+  QueueProxy() = default;
+
+  QueueProxy(size_t max_queues, size_t queue_size)
+    : max_queues_{max_queues}, queue_size_{queue_size},
+      total_queue_elements_{queue_size * max_queues},
+      queue_proxy_{max_queues},
+      per_block_queue_proxy_{queue_size * max_queues} {
+
     auto **queue_array{queue_proxy_.get()};
     auto *per_block_queue{per_block_queue_proxy_.get()};
-    for (size_t i{0}; i < MAX_NUM_BLOCKS; i++) {
-      queue_array[i] = per_block_queue + i * QUEUE_SIZE;
+    for (size_t i{0}; i < max_queues_; i++) {
+      queue_array[i] = per_block_queue + i * queue_size;
     }
     size_t total_queue_element_bytes{sizeof(queue_element_t) *
-                                     TOTAL_QUEUE_ELEMENTS};
+                                     total_queue_elements_};
     memset(per_block_queue, 0, total_queue_element_bytes);
   }
+
+  QueueProxy(const QueueProxy& other) = delete;
+
+  QueueProxy& operator=(const QueueProxy& other) = delete;
+
+  QueueProxy(QueueProxy&& other) = default;
+
+  QueueProxy& operator=(QueueProxy&& other) = default;
 
   __host__ __device__ queue_element_t **get() { return queue_proxy_.get(); }
 
@@ -126,6 +148,12 @@ class QueueProxy {
   ProxyT queue_proxy_{};
 
   ProxyPerBlockT per_block_queue_proxy_{};
+
+  size_t max_queues_{};
+
+  size_t queue_size_{};
+
+  size_t total_queue_elements_{};
 };
 
 using QueueProxyT = QueueProxy<HIPHostAllocator>;

--- a/src/reverse_offload/queue_proxy.hpp
+++ b/src/reverse_offload/queue_proxy.hpp
@@ -35,8 +35,6 @@
 
 namespace rocshmem {
 
-// constexpr size_t QUEUE_SIZE{512};
-
 struct cacheline_t {
   volatile char valid;
   volatile char padding[63];

--- a/src/reverse_offload/ro_team_proxy.hpp
+++ b/src/reverse_offload/ro_team_proxy.hpp
@@ -39,13 +39,23 @@ class ROTeamProxy {
   /*
    * Placement new the memory which is allocated by proxy_
    */
-  ROTeamProxy(Backend* backend, MPI_Comm comm, int pe, int npes)
-      : my_pe_(pe), team_size_(npes) {
+  ROTeamProxy(Backend* backend, MPI_Comm comm, int pe, int npes,
+              size_t num_elems = 1)
+    : my_pe_(pe), team_size_(npes), proxy_{num_elems} {
+
     MPI_Comm_dup(comm, &team_world_comm_);
 
     new (proxy_.get()) ROTeam(backend, wrt_parent_.get(), wrt_world_.get(),
                               team_size_, my_pe_, team_world_comm_);
   }
+
+  ROTeamProxy(const ROTeamProxy& other) = delete;
+
+  ROTeamProxy& operator=(const ROTeamProxy& other) = delete;
+
+  ROTeamProxy(ROTeamProxy&& other) = default;
+
+  ROTeamProxy& operator=(ROTeamProxy&& other) = default;
 
   /*
    * Since placement new is called in the constructor, then

--- a/src/reverse_offload/team_info_proxy.hpp
+++ b/src/reverse_offload/team_info_proxy.hpp
@@ -36,9 +36,18 @@ class TeamInfoProxy {
   /*
    * Placement new the memory which is allocated by proxy_
    */
-  TeamInfoProxy(Team* parent_team, int pe_start, int stride, int size) {
+  TeamInfoProxy(Team* parent_team, int pe_start, int stride, int size,
+    size_t num_elems = 1) : proxy_{num_elems} {
     new (proxy_.get()) TeamInfo(parent_team, pe_start, stride, size);
   }
+
+  TeamInfoProxy(const TeamInfoProxy& other) = delete;
+
+  TeamInfoProxy& operator=(const TeamInfoProxy& other) = delete;
+
+  TeamInfoProxy(TeamInfoProxy&& other) = default;
+
+  TeamInfoProxy& operator=(TeamInfoProxy&& other) = default;
 
   /*
    * Since placement new is called in the constructor, then

--- a/src/sync/abql_block_mutex.hpp
+++ b/src/sync/abql_block_mutex.hpp
@@ -111,9 +111,19 @@ class ABQLBlockMutex {
 
 template <typename ALLOCATOR>
 class ABQLBlockMutexProxy {
-  using ProxyT = DeviceProxy<ALLOCATOR, ABQLBlockMutex, 1>;
+  using ProxyT = DeviceProxy<ALLOCATOR, ABQLBlockMutex>;
 
  public:
+  ABQLBlockMutexProxy(size_t num_elems = 1) : proxy_{num_elems} {}
+
+  ABQLBlockMutexProxy(const ABQLBlockMutexProxy& other) = delete;
+
+  ABQLBlockMutexProxy& operator=(const ABQLBlockMutexProxy& other) = delete;
+
+  ABQLBlockMutexProxy(ABQLBlockMutexProxy&& other) = default;
+
+  ABQLBlockMutexProxy& operator=(ABQLBlockMutexProxy&& other) = default;
+
   __host__ __device__ ABQLBlockMutex* get() { return proxy_.get(); }
 
  private:


### PR DESCRIPTION
- Modified `DeviceProxy` class to determine memory allocation size at runtime.
- Updated all classes that include the `DeviceProxy` to use dynamic memory allocation.
- Removed compile-time memory size calculations.
- Ensured the allocated number of backend queue data structures matches the number of RO device contexts.