### PR TITLE
Sync Reverse Offload Scripts

### DIFF
--- a/scripts/build_configs/ro_ipc
+++ b/scripts/build_configs/ro_ipc
@@ -23,8 +23,9 @@ cmake \
     -DUSE_COHERENT_HEAP=ON \
     -DUSE_THREADS=OFF \
     -DUSE_WF_COAL=OFF \
-    -DUSE_SINGLE_NODE=ON \
     -DUSE_HOST_SIDE_HDP_FLUSH=OFF\
+    -DUSE_MANAGED_HEAP=OFF \
+    -DUSE_RO=ON \
     $src_path
 cmake --build . --parallel 8
 cmake --install .

--- a/scripts/build_configs/ro_net
+++ b/scripts/build_configs/ro_net
@@ -19,12 +19,13 @@ cmake \
     -DPROFILE=OFF \
     -DUSE_GPU_IB=OFF \
     -DUSE_DC=OFF \
+    -DUSE_IPC=OFF \
     -DUSE_COHERENT_HEAP=ON \
+    -DUSE_THREADS=OFF \
+    -DUSE_WF_COAL=OFF \
+    -DUSE_HOST_SIDE_HDP_FLUSH=OFF\
     -DUSE_MANAGED_HEAP=OFF \
     -DUSE_RO=ON \
-    -DUSE_IPC=ON \
-    -DUSE_THREADS=ON \
-    -DUSE_WF_COAL=OFF \
     $src_path
 cmake --build . --parallel 8
 cmake --install .

--- a/scripts/build_configs/ro_net_debug
+++ b/scripts/build_configs/ro_net_debug
@@ -20,9 +20,12 @@ cmake \
     -DUSE_GPU_IB=OFF \
     -DUSE_DC=OFF \
     -DUSE_IPC=OFF \
-    -DUSE_THREADS=ON \
+    -DUSE_COHERENT_HEAP=ON \
+    -DUSE_THREADS=OFF \
     -DUSE_WF_COAL=OFF \
-    -DUSE_COHERENT_HEAP=OFF \
+    -DUSE_HOST_SIDE_HDP_FLUSH=OFF\
+    -DUSE_MANAGED_HEAP=OFF \
+    -DUSE_RO=ON \
     $src_path
 cmake --build . --parallel 8
 cmake --install .

--- a/src/ipc_policy.hpp
+++ b/src/ipc_policy.hpp
@@ -125,6 +125,8 @@ class IpcOffImpl {
 
   char **ipc_bases{nullptr};
 
+  int *pes_with_ipc_avail{nullptr};
+
   __host__ void ipcHostInit(int my_pe, const HEAP_BASES_T &heap_bases,
                             MPI_Comm thread_comm) {}
 

--- a/tests/unit_tests/CMakeLists.txt
+++ b/tests/unit_tests/CMakeLists.txt
@@ -91,11 +91,18 @@ target_sources(
     #forward_list_gtest.cpp
     free_list_gtest.cpp
     #context_ipc_gtest.cpp
-    ipc_impl_simple_coarse_gtest.cpp
-    ipc_impl_simple_fine_gtest.cpp
-    ipc_impl_tiled_fine_gtest.cpp
     wavefront_size_gtest.cpp
 )
+
+if (USE_IPC)
+  target_sources(
+    ${PROJECT_NAME}
+    PRIVATE
+      ipc_impl_simple_coarse_gtest.cpp
+      ipc_impl_simple_fine_gtest.cpp
+      ipc_impl_tiled_fine_gtest.cpp
+  )
+endif()
 
 ###############################################################################
 # ROCSHMEM DEPENDENCY


### PR DESCRIPTION
- Disable IPC unit tests when IPC is not available in the rocSHMEM configuration