### PR TITLE
Fix/RO Backend Hang Issue

### DIFF
--- a/scripts/functional_tests/driver.sh
+++ b/scripts/functional_tests/driver.sh
@@ -179,19 +179,15 @@ TestRMA() {
 
   ExecTest  "teamctxget"       2       1            1         1048576
 
-  ExecTest  "g"                2       1            1         1048576
-  ExecTest  "g"                2       1            1024      512
-  ExecTest  "g"                2       8            1         1048576
-  ExecTest  "g"                2       16           128       8
-  ExecTest  "g"                2       32           256       512
-  ExecTest  "g"                2       64           1024      8
+  ExecTest  "g"                2       1            1         128
+  ExecTest  "g"                2       1            1024      2
+  ExecTest  "g"                2       8            1         32
+  ExecTest  "g"                2       16           128       4
 
-  ExecTest  "p"                2       1            1         1048576
-  ExecTest  "p"                2       1            1024      512
-  ExecTest  "p"                2       8            1         1048576
-  ExecTest  "p"                2       16           128       8
-  ExecTest  "p"                2       32           256       512
-  ExecTest  "p"                2       64           1024      8
+  ExecTest  "p"                2       1            1         128
+  ExecTest  "p"                2       1            1024      2
+  ExecTest  "p"                2       8            1         32
+  ExecTest  "p"                2       16           128       4
 
   ################################ Non-Blocking ################################
 

--- a/src/memory/hip_allocator.hpp
+++ b/src/memory/hip_allocator.hpp
@@ -37,7 +37,8 @@
 #include "memory_allocator.hpp"
 
 // `hipDeviceMallocUncached` was introduced at ROCm 5.5
-#if HIP_VERSION_MAJOR >= 5 && HIP_VERSION_MINOR >= 5
+#if (HIP_VERSION_MAJOR > 5) || \
+    (HIP_VERSION_MAJOR == 5 && HIP_VERSION_MINOR >= 5)
 #define HIP_SUPPORTS_MALLOC_UNCACHED
 #endif
 namespace rocshmem {

--- a/src/reverse_offload/block_handle.hpp
+++ b/src/reverse_offload/block_handle.hpp
@@ -83,7 +83,7 @@ class DefaultBlockHandleProxy {
   ProxyT proxy_{};
 };
 
-using DefaultBlockHandleProxyT = DefaultBlockHandleProxy<HIPAllocator>;
+using DefaultBlockHandleProxyT = DefaultBlockHandleProxy<HIPDefaultFinegrainedAllocator>;
 
 template <typename ALLOCATOR>
 class BlockHandleProxy {
@@ -130,7 +130,7 @@ class BlockHandleProxy {
   size_t num_blocks_{};
 };
 
-using BlockHandleProxyT = BlockHandleProxy<HIPAllocator>;
+using BlockHandleProxyT = BlockHandleProxy<HIPDefaultFinegrainedAllocator>;
 
 }  // namespace rocshmem
 


### PR DESCRIPTION
- Update HIP version check for compatibility with versions >= `5.5`
- Update memory allocator for context `BlockHandle`
  - Replaced `HIPAllocator` with `HIPDefaultFinegrainedAllocator` to resolve hang issue
- Updated run commands for `rocshmem_g` and `rocshmem_p` functional tests