### PR TITLE
Bug fix for PR43

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,15 +112,6 @@ rocm_setup_version(VERSION 2.0.0)
 project(rocshmem VERSION 2.0.0 LANGUAGES CXX)
 
 ###############################################################################
-# TEST SUBDIRECTORIES
-###############################################################################
-add_subdirectory(tests)
-
-if (BUILD_EXAMPLES)
-  add_subdirectory(examples)
-endif()
-
-###############################################################################
 # CREATE ROCSHMEM LIBRARY
 ###############################################################################
 if (NOT BUILD_TESTS_ONLY)
@@ -211,7 +202,18 @@ if (NOT BUILD_TESTS_ONLY)
         ${IBVERBS_LIBRARIES}
     )
   endif()
+endif()
 
+###############################################################################
+# TEST SUBDIRECTORIES
+###############################################################################
+add_subdirectory(tests)
+
+if (BUILD_EXAMPLES)
+  add_subdirectory(examples)
+endif()
+
+if (NOT BUILD_TESTS_ONLY)
   #############################################################################
   # INSTALL
   #############################################################################

--- a/scripts/build_configs/ipc_tests_only
+++ b/scripts/build_configs/ipc_tests_only
@@ -33,5 +33,8 @@ cmake \
     -DUSE_HOST_SIDE_HDP_FLUSH=OFF \
     -DBUILD_LOCAL_GPU_TARGET_ONLY=OFF \
     -DBUILD_TESTS_ONLY=ON \
+    -DBUILD_FUNCTIONAL_TESTS=ON \
+    -DBUILD_EXAMPLES=ON \
+    -DBUILD_UNIT_TESTS=OFF \
     $src_path
 cmake --build . --parallel 8


### PR DESCRIPTION
When `find_package(hip REQUIRED)` is called (see [1]), it overrides the desired the desired targets we wish to compile for. Thus, it must be moved so it is after our target selection logic in the cmakefiles.

I have also updated the `ipc_tests_only` build config to help with RC testing 



[1] https://github.com/ROCm/rocSHMEM/blob/develop/tests/unit_tests/CMakeLists.txt#L103