### PR TITLE
ROCm 6.4.0rc3 bug fix

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -63,6 +63,7 @@ foreach(SOURCE_FILE IN LISTS EXAMPLE_SOURCES)
       PRIVATE
         ${MPI_mpi_LIBRARY}
         ${MPI_mpicxx_LIBRARY}
+        ${flags_str}
         -L${ROCSHMEM_HOME}/lib
         -lamdhip64
         -lhsa-runtime64

--- a/tests/functional_tests/CMakeLists.txt
+++ b/tests/functional_tests/CMakeLists.txt
@@ -91,6 +91,7 @@ if (BUILD_TESTS_ONLY)
     PRIVATE
       ${MPI_mpi_LIBRARY}
       ${MPI_mpicxx_LIBRARY}
+      ${flags_str}
       -L${ROCSHMEM_HOME}/lib
       -lamdhip64
       -lhsa-runtime64


### PR DESCRIPTION
Required to link tests for ROCm 6.4.0rc3.

We do not need to cherry-pick this into 6.4.0 branch as the functional tests are not packaged as a part of ROCm