### PR TITLE
Fix rocshmem_TYPE_g for IPC

### DIFF
--- a/src/ipc/context_ipc_tmpl_device.hpp
+++ b/src/ipc/context_ipc_tmpl_device.hpp
@@ -55,6 +55,7 @@ __device__ void IPCContext::put_nbi(T *dest, const T *source, size_t nelems,
 template <typename T>
 __device__ T IPCContext::g(const T *source, int pe) {
   T ret;
+  getmem(&ret, source, sizeof(T), pe);
   return ret;
 }
 


### PR DESCRIPTION
This bug fix is in develop (#31) but it has not been incorporated into ROCm 6.4.x