### PR TITLE
Performance tuning for inter-node communication

### DIFF
--- a/src/host/host.hpp
+++ b/src/host/host.hpp
@@ -341,7 +341,7 @@ class HostInterface {
   /**
    * @brief Max number of contexts for the application
    */
-  int max_num_ctxs_{40};
+  int max_num_ctxs_{1};
 
   /**
    * @brief Pool of HostContexWindowInfos

--- a/src/reverse_offload/mpi_transport.cpp
+++ b/src/reverse_offload/mpi_transport.cpp
@@ -25,6 +25,7 @@
 #include <functional>
 #include <utility>
 #include <vector>
+#include <unistd.h>
 
 #include "../host/host.hpp"
 #include "backend_ro.hpp"
@@ -591,6 +592,10 @@ void MPITransport::progress() {
     const int tag{1000};
     int flag{0};
     MPI_Status status{};
+
+    // Slowing the progress engine down a bit avoid hammering the memory subsystem.
+    // This leads to significant performance benefits
+    usleep (rocshmem_env_config.ro_progress_delay);
     NET_CHECK(MPI_Iprobe(MPI_ANY_SOURCE, tag, ro_net_comm_world, &flag, &status));
   } else {
     DPRINTF("Testing all outstanding requests (%zu)\n", requests.size());

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -155,6 +155,12 @@ void rocshmem_env_config_init(void) {
   if (NULL != env_value) {
     rocshmem_env_config.ro_disable_ipc = atoi(env_value);
   }
+
+  env_value = getenv("ROCSHMEM_RO_PROGRESS_DELAY");
+  if (nullptr != env_value) {
+    rocshmem_env_config.ro_progress_delay = atoi(env_value);
+  }
+
 }
 
 }  // namespace rocshmem

--- a/src/util.hpp
+++ b/src/util.hpp
@@ -271,6 +271,7 @@ uint64_t wallClk_freq_mhz();
 
 struct rocshmem_env_config_t {
   int ro_disable_ipc = 0;
+  int ro_progress_delay = 3;
 };
 extern struct rocshmem_env_config_t rocshmem_env_config;
 


### PR DESCRIPTION
This PR addresses two issues:
 - reduce the number of contexts supported by the host-interface by default to 1, we are not using those at the moment, and hence we now create fewer MPI_Win at the startup
 - introduces a micro-sleep in RO progress engine in case there are no pending requests. This leads significant performance improvements observed for inter-node communication with THor2 NICs.
 
Here are some performance numbers documenting the benefits of this patch:
```
### Creating Test: Non-Blocking Puts ###
# Size (B)       Latency new (us)   Latency orig (us)  
1                       17.18 	           62.23  
2                       19.26 	           68.76  
4                       34.17 	           62.88  
8                       13.25 	           61.15  
16                      33.98 	           68.51  
32                      37.37 	           62.30  
64                      34.76 	           56.10  
128                     37.41 	           56.10  
256                     24.98 	           56.10  
512                     37.38 	           56.10  
1024                    24.92 	           56.10  
2048                    43.64 	           49.87  
4096                    21.14 	           56.10  
8192                    24.61 	           49.83  
16384                   37.93 	           31.16  
32768                   37.74 	           49.89  
65536                   20.73 	           62.29  
131072                  18.22 	           55.93  
262144                  37.86 	           56.07  
524288                  78.41 	          113.05  
1048576                 96.00 	          162.04  

### Creating Test: Non-Blocking Gets ###
# Size (B)s        Latency new (us)  Latency (us)
1                         24.21	            63.93
2                         44.44	            73.50
4                         57.55	            75.92
8                         40.67	            84.58
16                        41.31	            50.53
32                        46.66	            47.75
64                        19.14	            52.39
128                       15.61	            31.14
256                        8.04	            56.08
512                       27.60	            56.07
1024                      16.42	            49.85
2048                       7.78	            56.12
4096                      16.25	            56.04
8192                      12.47	            56.07
16384                      7.82	            56.02
32768                      7.95	            49.80
65536                     31.17	            43.63
131072                    37.39	            62.37
262144                    29.12             56.13
524288                    54.57            106.02
1048576                  115.60            117.82

### Creating Test: Blocking WG level Puts ###
# Size (B)       Latency new (us)   Latency orig (us)
1                      129.30 	        39913.73
2                      129.12 	        40710.22
4                      129.48 	        38716.65
8                      129.29 	        38716.52
16                      69.39 	        39514.80
32                     134.75 	        35124.43
64                     129.94 	        37918.27
128                     69.69 	        37519.10
256                     69.74 	        39115.85
512                    129.19 	        37119.90
1024                   129.55 	        41510.51
2048                   129.65 	        39914.13
4096                    69.77 	        39914.07
8192                  2035.78 	        36720.94
16384                  129.84 	        37519.18
32768                  130.56 	        38317.42
65536                   70.80 	        39115.96
131072                  71.63 	        37519.26
262144                 138.88 	        39913.85
524288                 109.33 	        41111.46
1048576                167.63 	        38317.65

### Creating Test: Blocking WAVE level Puts ###
# Size (B)       Latency new (us)  Latency orig (us)
1                      129.38 	       39115.62
2                      129.65 	       37519.04
4                       75.26 	       37918.29
8                      129.45 	       39913.91
16                      67.32 	       35924.93
32                     135.16 	       37119.91
64                     129.33 	       38718.59
128                     96.70 	       37918.44
256                     69.60 	       39914.10
512                     69.75 	       38716.77
1024                    69.74 	       38317.44
2048                   129.75 	       37917.14
4096                    69.91 	       38317.49
8192                   119.58 	       36321.76
16384                  129.95 	       37918.17
32768                   70.35 	       38716.50
65536                  129.57 	       41111.37
131072                 132.34 	       39515.00
262144                 137.42 	       40712.39
524288                 153.14 	       37918.32
1048576                108.66 	       37919.39
```


