### PR TITLE
add uniqueID initialization

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -29,6 +29,7 @@ set(EXAMPLE_SOURCES
   rocshmem_broadcast_test.cc
   rocshmem_getmem_test.cc
   rocshmem_put_signal_test.cc
+  rocshmem_init_attr_test.cc
 )
 
 foreach(SOURCE_FILE IN LISTS EXAMPLE_SOURCES)

--- a/examples/rocshmem_init_attr_test.cc
+++ b/examples/rocshmem_init_attr_test.cc
@@ -1,0 +1,68 @@
+/*
+hipcc -c -fgpu-rdc -x hip rocshmem_init_attr_test.cc \
+  -I/opt/rocm/include \
+  -I$ROCSHMEM_INSTALL_DIR/include \
+  -I$OPENMPI_UCX_INSTALL_DIR/include/
+
+hipcc -fgpu-rdc --hip-link rocshmem_init_attr_test.o -o rocshmem_init_attr_test \
+  $ROCSHMEM_INSTALL_DIR/lib/librocshmem.a \
+  $OPENMPI_UCX_INSTALL_DIR/lib/libmpi.so \
+  -L/opt/rocm/lib -lamdhip64 -lhsa-runtime64
+
+ROCSHMEM_MAX_NUM_CONTEXTS=2 mpirun -np 2 ./rocshmem_init_attr_test
+*/
+
+#include <iostream>
+
+#include <hip/hip_runtime_api.h>
+#include <hip/hip_runtime.h>
+#include <rocshmem/rocshmem.hpp>
+
+#define CHECK_HIP(condition) {                                            \
+        hipError_t error = condition;                                     \
+        if(error != hipSuccess){                                          \
+            fprintf(stderr,"HIP error: %d line: %d\n", error,  __LINE__); \
+            MPI_Abort(MPI_COMM_WORLD, error);                             \
+        }                                                                 \
+    }
+
+using namespace rocshmem;
+
+int main (int argc, char **argv)
+{
+    int rank, nranks;
+    int ret;
+    rocshmem_uniqueid_t uid;
+    rocshmem_init_attr_t attr;
+
+    MPI_Init(&argc, &argv);
+    MPI_Comm_rank (MPI_COMM_WORLD, &rank);
+    MPI_Comm_size (MPI_COMM_WORLD, &nranks);
+
+    if (rank == 0) {
+      ret = rocshmem_get_uniqueid (&uid);
+      if (ret != ROCSHMEM_SUCCESS) {
+	std::cout << rank << ": Error in rocshmem_get_uniqueid. Aborting.\n";
+	MPI_Abort (MPI_COMM_WORLD, ret);
+      }
+    }
+
+    MPI_Bcast (&uid, sizeof(rocshmem_uniqueid_t), MPI_BYTE, 0, MPI_COMM_WORLD);
+    ret = rocshmem_set_attr_uniqueid_args(rank, nranks, &uid, &attr);
+    if (ret != ROCSHMEM_SUCCESS) {
+      std::cout << rank << ": Error in rocshmem_set_attr_uniqueid_args. Aborting.\n";
+      MPI_Abort (MPI_COMM_WORLD, ret);
+    }
+    
+    ret = rocshmem_init_attr(ROCSHMEM_INIT_WITH_UNIQUEID, &attr);
+    if (ret != ROCSHMEM_SUCCESS) {
+      std::cout << rank << ": Error in rocshmem_init_attr. Aborting.\n";
+      MPI_Abort (MPI_COMM_WORLD, ret);
+    }
+
+    std::cout << rank << ": rocshmem_init_attr SUCCESS\n";
+
+    rocshmem_finalize();
+    MPI_Finalize();
+    return 0;
+}

--- a/include/rocshmem/rocshmem.hpp
+++ b/include/rocshmem/rocshmem.hpp
@@ -71,10 +71,50 @@ __host__ void rocshmem_init(MPI_Comm comm = MPI_COMM_WORLD);
  *                      to requested thread mode.
  * @param[in] comm      (Optional) MPI Communicator that rocSHMEM will be using
  *                      If MPI_COMM_NULL, rocSHMEM will be using MPI_COMM_WORLD
+ *
+ * @return int          returns 0 upon success; otherwise, it returns a nonzero
+ *                      value
  */
-__host__ void rocshmem_init_thread(int requested, int *provided,
-                                    MPI_Comm comm = MPI_COMM_WORLD);
+__host__ int rocshmem_init_thread(int requested, int *provided,
+                                  MPI_Comm comm = MPI_COMM_WORLD);
 
+/**
+ * @brief Initialize the rocSHMEM runtime and underlying transport layer
+ *        using the provided mode and attributes
+ *
+ * @param[in] flags   initialization method to be used.
+ *                    Valid values are ROCSHMEM_INIT_WITH_UNIQUEID and
+ *                    ROCSHMEM_INIT_WITH_MPI_COMM
+ * @param[in] attr    attribute structure specifying input characteristics
+ *
+ * @return int        returns 0 upon success; otherwise, it returns a nonzero
+ *                    value
+ */
+__host__ int rocshmem_init_attr(unsigned int flags, rocshmem_init_attr_t *attr);
+
+/**
+ * @brief Return a uniqueID
+ *
+ * @return int        returns 0 upon success; otherwise, it returns a nonzero
+ *                    value
+ */
+__host__ int rocshmem_get_uniqueid(rocshmem_uniqueid_t *uid);
+
+/**
+ * @brief Query the thread mode used by the runtime.
+ *
+ * @param[in] rank     rank of the calling process
+ * @param[in] nranks   number of pes
+ * @param[in] uid      unique ID used to identify the group processes.
+ *                     All processes that
+ * @param[out] attr    attribute structure to be passed to rocshmem_init_attr
+ *
+ * @return int         returns 0 upon success; otherwise, it returns a nonzero
+ *                     value
+ */
+__host__ int rocshmem_set_attr_uniqueid_args(int rank, int nranks,
+                                             rocshmem_uniqueid_t *uid,
+                                             rocshmem_init_attr_t *attr);
 /**
  * @brief Query the thread mode used by the runtime.
  *

--- a/include/rocshmem/rocshmem_common.hpp
+++ b/include/rocshmem/rocshmem_common.hpp
@@ -125,6 +125,32 @@ extern rocshmem_team_t ROCSHMEM_TEAM_WORLD;
 
 const rocshmem_team_t ROCSHMEM_TEAM_INVALID = nullptr;
 
+/**
+ * @brief  Data structure defining the unqiueId
+ */
+constexpr int ROCSHMEM_HOSTNAME_LEN = 20;
+struct rocshmem_uniqueid_t {
+  uint64_t random;
+  char hostname[ROCSHMEM_HOSTNAME_LEN];
+  uint32_t pid;
+};
+typedef struct rocshmem_uniqueid_t rocshmem_unique_id_t;
+
+/**
+ * @brief Data structure used for attribute based 
+ *        initialization
+ */
+struct rocshmem_init_attr_t  {
+  int32_t rank;
+  int32_t nranks;
+  rocshmem_uniqueid_t uid;
+  void* mpi_comm;
+};
+typedef struct rocshmem_init_attr_t rocshmem_init_attr_t;
+
+constexpr unsigned int ROCSHMEM_INIT_WITH_MPI_COMM = 0;
+constexpr unsigned int ROCSHMEM_INIT_WITH_UNIQUEID = 1;
+
 }  // namespace rocshmem
 
 #endif  // LIBRARY_INCLUDE_ROCSHMEM_COMMON_HPP


### PR DESCRIPTION
add the interfaces required to support rocshmem initialization through the uniqueID mechanism. At the moment this still maps to MPI initialization underneath the hood, but adding the functions might simplify the porting of some applications to rocshmem. In addition, if we need to transition away from MPI one day, this is also one step into this direction.

In addition, change the interface of `rocshmem_init_thread()` from void to int, to match the SHMEM spec.