### PR TITLE
Show and log what the functional test driver is running

### DIFF
--- a/scripts/functional_tests/driver.sh
+++ b/scripts/functional_tests/driver.sh
@@ -142,10 +142,12 @@ ExecTest() {
     TEST_LOG_NAME+=_"$MAX_MSG_SIZE"B
   fi
 
-  CMD+=" > $LOG_DIR/$TEST_LOG_NAME.log"
+  CMD+=" >> $LOG_DIR/$TEST_LOG_NAME.log"
 
   # Run Test
-  echo $TEST_LOG_NAME
+  # echo $TEST_LOG_NAME
+  echo $CMD
+  echo "# $CMD" >"$LOG_DIR/$TEST_LOG_NAME.log"
   eval $CMD
 
   # Validate Test

--- a/scripts/functional_tests/driver.sh
+++ b/scripts/functional_tests/driver.sh
@@ -160,6 +160,7 @@ ExecTest() {
   if [ $? -ne 0 ]
   then
     echo -e "$PRETTY_FAILED: $TEST_LOG_NAME" >&2
+    cat "$LOG_DIR/$TEST_LOG_NAME.log"
     DRIVER_RETURN_STATUS=1
     FAILED_LIST="$FAILED_LIST $TEST_LOG_NAME"
   fi
@@ -493,9 +494,10 @@ case $TEST in
     ;;
 esac
 
-if [ -z "$FAILED_LIST" ]; then
+EXIT_STATUS=$(($DRIVER_RETURN_STATUS || $?))
+if [ $EXIT_STATUS -eq 0 ]; then
   echo -e "TESTS PASSED"
 else
   echo -e "TESTS FAILED: $FAILED_LIST"
 fi
-exit $(($DRIVER_RETURN_STATUS || $?))
+exit $EXIT_STATUS

--- a/scripts/functional_tests/driver.sh
+++ b/scripts/functional_tests/driver.sh
@@ -19,6 +19,13 @@
 # THE SOFTWARE.
 
 #!/bin/bash
+if true || tty -s; then
+  PRETTY_FAILED="\033[1;31mFAILED\033[0m"
+  PRETTY_PASSED="\033[1;32mPASSED\033[0m"
+else
+  PRETTY_FAILED="FAILED"
+  PRETTY_PASSED="PASSED"
+fi
 
 # This names/values should match the TestType enum in rocSHMEM/tests/functional_tests/tester.hpp
 declare -A TEST_NUMBERS=(
@@ -142,19 +149,19 @@ ExecTest() {
     TEST_LOG_NAME+=_"$MAX_MSG_SIZE"B
   fi
 
-  CMD+=" >> $LOG_DIR/$TEST_LOG_NAME.log"
+  CMD+=" >> $LOG_DIR/$TEST_LOG_NAME.log 2>&1"
 
   # Run Test
-  # echo $TEST_LOG_NAME
-  echo $CMD
+  echo $TEST_LOG_NAME
   echo "# $CMD" >"$LOG_DIR/$TEST_LOG_NAME.log"
   eval $CMD
 
   # Validate Test
   if [ $? -ne 0 ]
   then
-    echo "Failed $TEST_CONFIG" >&2
+    echo -e "$PRETTY_FAILED: $TEST_LOG_NAME" >&2
     DRIVER_RETURN_STATUS=1
+    FAILED_LIST="$FAILED_LIST $TEST_LOG_NAME"
   fi
 
   unset ROCSHMEM_MAX_NUM_CONTEXTS
@@ -486,4 +493,9 @@ case $TEST in
     ;;
 esac
 
+if [ -z "$FAILED_LIST" ]; then
+  echo -e "TESTS PASSED"
+else
+  echo -e "TESTS FAILED: $FAILED_LIST"
+fi
 exit $(($DRIVER_RETURN_STATUS || $?))


### PR DESCRIPTION
Tyical output looks like 
```salloc -whostname -N1 -n2 --gpus-per-task=1 -c6   ../rocSHMEM/scripts/functional_tests/driver.sh tests/functional_tests/rocshmem_example_driver amo logs
amo_fetch_n2_w1_z1
....
amo_add_n2_w8_z1
amo_add_n2_w32_z128
amo_fetchand_n2_w1_z1
FAILED: amo_fetchand_n2_w1_z1
# mpirun  -n 2 -mca pml ucx -mca osc ucx -x ROCSHMEM_MAX_NUM_CONTEXTS=1 -x UCX_ROCM_IPC_SIGPOOL_MAX_ELEMS=16384 --map-by numa --timeout 300 tests/functional_tests/rocshmem_example_driver -a 42 -w 1 -z 1 >> logs/amo_fetchand_n2_w1_z1.log 2>&1
### Creating Test: AMO Fetch And ###
/home/bouteill/rocshmem/rocSHMEM/src/ipc/context_ipc_tmpl_device.hpp:99: T rocshmem::IPCContext::amo_fetch_and(void *, T, int) [T = unsigned long long]: Device-side assertion `false' failed.
:0:rocdevice.cpp            :3006: 1002551936626 us:  Callback: Queue 0x7fccf4800000 aborting with error : HSA_STATUS_ERROR_EXCEPTION: An HSAIL operation resulted in a hardware exception. code: 0x1016
[dopamine:2475206] *** Process received signal ***
[dopamine:2475206] Signal: Aborted (6)
[dopamine:2475206] Signal code:  (-6)
...
[dopamine:2475206] [ 7] /apps/rocm/rocm-6.4afar7/lib/libhsa-runtime64.so.1(+0x2e73d)[0x7fce1174273d]
[dopamine:2475206] [ 8] /lib64/libc.so.6(+0x897e2)[0x7fce1126a7e2]
[dopamine:2475206] [ 9] /lib64/libc.so.6(+0x10e800)[0x7fce112ef800]
[dopamine:2475206] *** End of error message ***
--------------------------------------------------------------------------
prterun noticed that process rank 0 with PID 2475206 on node dopamine exited on
signal 6 (Aborted).
--------------------------------------------------------------------------
amo_and_n2_w1_z1
FAILED: amo_and_n2_w1_z1
# mpirun  -n 2 -mca pml ucx -mca osc ucx -x ROCSHMEM_MAX_NUM_CONTEXTS=1 -x UCX_ROCM_IPC_SIGPOOL_MAX_ELEMS=16384 --map-by numa --timeout 300 tests/functional_tests/rocshmem_example_driver -a 45 -w 1 -z 1 >> logs/amo_and_n2_w1_z1.log 2>&1
...

TESTS FAILED:  amo_fetchand_n2_w1_z1 amo_and_n2_w1_z1 amo_xor_n2_w1_z1
```