### PR TITLE
Update backend to use provided MPI communicator during library initialization

### DIFF
--- a/src/backend_bc.hpp
+++ b/src/backend_bc.hpp
@@ -67,7 +67,7 @@ class Backend {
    * @note Implementation may reduce the number of workgroups if the
    * number exceeds hardware limits.
    */
-  explicit Backend();
+  explicit Backend(MPI_Comm comm);
 
   /**
    * @brief Destructor.
@@ -221,7 +221,7 @@ class Backend {
    * @todo document where this is used and try to coalesce this into another
    * class
    */
-  MPI_Comm thread_comm{};
+  MPI_Comm backend_comm{};
 
   /**
    * @brief Object contains the interface and internal data structures
@@ -295,6 +295,13 @@ class Backend {
    * @brief List of ctxs created by the user.
    */
   std::vector<Context*> list_of_ctxs{};
+
+  /**
+   * @brief initialize MPI.
+   *
+   * Backend relies on MPI to exchange meta data across PEs.
+   */
+  void init_mpi_once(MPI_Comm comm);
 };
 
 /**

--- a/src/ipc/backend_ipc.hpp
+++ b/src/ipc/backend_ipc.hpp
@@ -65,16 +65,6 @@ class IPCBackend : public Backend {
    */
   void ctx_destroy(Context *ctx) override;
 
-   /**
-   * @brief initialize MPI.
-   *
-   * IPC relies on MPI just to exchange the IPC_handle information.
-   *
-   * todo: remove the dependency on MPI and make it generic to PMI-X or just
-   * to OpenSHMEM to have support for both CPU and GPU
-   */
-  void init_mpi_once(MPI_Comm comm);
-
   /**
    * @brief Helper to initialize IPC interface.
    */

--- a/src/memory/remote_heap_info.hpp
+++ b/src/memory/remote_heap_info.hpp
@@ -50,7 +50,9 @@ class CommunicatorMPI {
   /**
    * @brief Primary constructor
    */
-  CommunicatorMPI(char* heap_base, size_t heap_size) {
+  CommunicatorMPI(char* heap_base, size_t heap_size,
+                  MPI_Comm comm = MPI_COMM_WORLD)
+    : comm_{comm} {
     int initialized;
     MPI_Initialized(&initialized);
     if (!initialized) {
@@ -87,8 +89,8 @@ class CommunicatorMPI {
    * @brief Performs MPI_Allgather on recvbuf
    */
   void allgather(void* recvbuf) {
-    MPI_Allgather(MPI_IN_PLACE, sizeof(void*), MPI_CHAR, recvbuf, sizeof(void*),
-                  MPI_CHAR, comm_);
+    MPI_Allgather(MPI_IN_PLACE, sizeof(void*), MPI_CHAR, recvbuf,
+                  sizeof(void*), MPI_CHAR, comm_);
   }
 
   /**
@@ -100,7 +102,7 @@ class CommunicatorMPI {
   /**
    * @brief Identifier for this processing element
    */
-  MPI_Comm comm_{MPI_COMM_WORLD};
+  MPI_Comm comm_{};
 
   /**
    * @brief Identifier for this processing element
@@ -139,8 +141,9 @@ class RemoteHeapInfo {
    * @param[in] The identifier for this processing element
    * @param[in] The total number of processing elements
    */
-  RemoteHeapInfo(char* heap_ptr, size_t heap_size)
-      : communicator_{heap_ptr, heap_size} {
+  RemoteHeapInfo(char* heap_ptr, size_t heap_size,
+                 MPI_Comm comm = MPI_COMM_WORLD)
+    : communicator_{heap_ptr, heap_size, comm} {
     heap_bases_.resize(communicator_.num_pes());
     for (auto& base : heap_bases_) {
       base = nullptr;

--- a/src/memory/symmetric_heap.hpp
+++ b/src/memory/symmetric_heap.hpp
@@ -54,6 +54,10 @@ class SymmetricHeap {
   using RemoteHeapInfoType = RemoteHeapInfo<CommunicatorMPI>;
 
  public:
+  SymmetricHeap(MPI_Comm comm = MPI_COMM_WORLD)
+    : remote_heap_info_{single_heap_.get_base_ptr(),
+                        single_heap_.get_size(),
+                        comm} {}
   /**
    * @brief Allocates heap memory and returns ptr to caller
    *
@@ -120,8 +124,7 @@ class SymmetricHeap {
   /**
    * @brief Implementation of remote heaps
    */
-  RemoteHeapInfoType remote_heap_info_{single_heap_.get_base_ptr(),
-                                       single_heap_.get_size()};
+  RemoteHeapInfoType remote_heap_info_{};
 };
 
 }  // namespace rocshmem

--- a/src/memory/window_info.hpp
+++ b/src/memory/window_info.hpp
@@ -165,7 +165,7 @@ class WindowInfo {
   /**
    * @brief MPI Communicator
    */
-  MPI_Comm comm_{MPI_COMM_WORLD};
+  MPI_Comm comm_{};
 
   /**
    * @brief Owning pointer to MPI_Win

--- a/src/reverse_offload/backend_ro.cpp
+++ b/src/reverse_offload/backend_ro.cpp
@@ -45,7 +45,7 @@ namespace rocshmem {
 extern rocshmem_ctx_t ROCSHMEM_HOST_CTX_DEFAULT;
 
 ROBackend::ROBackend(MPI_Comm comm)
-    : Backend() {
+    : Backend(comm) {
   type = BackendType::RO_BACKEND;
 
   if (auto maximum_num_contexts_str = getenv("ROCSHMEM_MAX_NUM_CONTEXTS")) {
@@ -78,7 +78,7 @@ ROBackend::ROBackend(MPI_Comm comm)
 
   queue_ = Queue(maximum_num_contexts_, queue_size_);
 
-  transport_ = new MPITransport(comm, &queue_);
+  transport_ = new MPITransport(backend_comm, &queue_);
   num_pes = transport_->getNumPes();
   my_pe = transport_->getMyPe();
 

--- a/src/reverse_offload/mpi_transport.cpp
+++ b/src/reverse_offload/mpi_transport.cpp
@@ -54,7 +54,7 @@ MPITransport::MPITransport(MPI_Comm comm, Queue* q)
       std::cerr << "MPI_THREAD_MULTIPLE support disabled.\n";
     }
   }
-  if (comm == MPI_COMM_NULL) comm = MPI_COMM_WORLD;
+  assert(comm != MPI_COMM_NULL);
 
   NET_CHECK(MPI_Comm_dup(comm, &ro_net_comm_world));
   NET_CHECK(MPI_Comm_size(ro_net_comm_world, &num_pes));

--- a/src/rocshmem.cpp
+++ b/src/rocshmem.cpp
@@ -197,13 +197,24 @@ rocshmem_ctx_t ROCSHMEM_HOST_CTX_DEFAULT;
 }
 
 [[maybe_unused]] __host__ int rocshmem_my_pe() {
-  MPIInitSingleton *s = s->GetInstance();
-  return s->get_rank();
+  if(backend == nullptr) {
+    MPIInitSingleton *s = s->GetInstance();
+    return s->get_rank();
+  }
+  else
+  {
+    return backend->getMyPE();
+  }
 }
 
 [[maybe_unused]] __host__ int rocshmem_n_pes() {
-  MPIInitSingleton *s = s->GetInstance();
-  return s->get_nprocs();
+  if(backend == nullptr) {
+    MPIInitSingleton *s = s->GetInstance();
+    return s->get_nprocs();
+  }
+  else {
+    return backend->getNumPEs();
+  }
 }
 
 [[maybe_unused]] __host__ void *rocshmem_malloc(size_t size) {


### PR DESCRIPTION
Updated backend to use the MPI communicator passed during the library initialization. If no communicator is explicitly provided, it defaults to `MPI_COMM_WORLD`.