### PR TITLE
bugfix: do not dereference ctx during create_ctx if we did run out of ctx

### DIFF
--- a/src/rocshmem_gpu.cpp
+++ b/src/rocshmem_gpu.cpp
@@ -287,7 +287,9 @@ __device__ int rocshmem_wg_ctx_create(long option, rocshmem_ctx_t *ctx) {
   if (get_flat_block_id() == 0) {
     ctx->team_opaque = reinterpret_cast<TeamInfo *>(ROCSHMEM_CTX_DEFAULT.team_opaque);
     result = device_backend_proxy->create_ctx(option, ctx);
-    reinterpret_cast<Context *>(ctx->ctx_opaque)->setFence(option);
+    if(result) {
+      reinterpret_cast<Context *>(ctx->ctx_opaque)->setFence(option);
+    }
   }
   __syncthreads();
   return result == true ? 0 : -1;
@@ -306,7 +308,9 @@ __device__ int rocshmem_wg_team_create_ctx(rocshmem_team_t team, long options,
     TeamInfo *info_wrt_world = team_obj->tinfo_wrt_world;
     ctx->team_opaque = info_wrt_world;
     result = device_backend_proxy->create_ctx(options, ctx);
-    reinterpret_cast<Context *>(ctx->ctx_opaque)->setFence(options);
+    if(result) {
+      reinterpret_cast<Context *>(ctx->ctx_opaque)->setFence(options);
+    }
   }
   __syncthreads();
 

--- a/tests/functional_tests/team_ctx_infra_tester.cpp
+++ b/tests/functional_tests/team_ctx_infra_tester.cpp
@@ -49,9 +49,12 @@ __global__ void TeamCtxInfraTest(ShmemContextType ctx_type,
    */
 
   rocshmem_wg_team_create_ctx(team[0], ctx_type, &ctx1);
+  assert (nullptr != ctx1.ctx_opaque);
   rocshmem_wg_team_create_ctx(team[0], ctx_type, &ctx2);
+  assert (nullptr != ctx2.ctx_opaque);
   rocshmem_wg_ctx_destroy(&ctx1);
   rocshmem_wg_team_create_ctx(team[0], ctx_type, &ctx3);
+  assert (nullptr != ctx3.ctx_opaque);
 
   __syncthreads();
 
@@ -71,6 +74,7 @@ __global__ void TeamCtxInfraTest(ShmemContextType ctx_type,
    */
   for (int team_i = 0; team_i < NUM_TEAMS; team_i++) {
     rocshmem_wg_team_create_ctx(team[team_i], ctx_type, &ctx[team_i]);
+    assert (nullptr != ctx.ctx_opaque);
   }
 
   if (ctx[0].team_opaque == ctx[NUM_TEAMS - 1].team_opaque) {
@@ -131,7 +135,7 @@ void TeamCtxInfraTester::launchKernel(dim3 gridSize, dim3 blockSize, int loop,
             sizeof(rocshmem_team_t) * NUM_TEAMS, hipMemcpyHostToDevice));
 
   hipLaunchKernelGGL(TeamCtxInfraTest, gridSize, blockSize, shared_bytes,
-		     stream, _shmem_context, teams_on_device);
+                     stream, _shmem_context, teams_on_device);
 
   CHECK_HIP(hipFree(teams_on_device));
 }


### PR DESCRIPTION
This scenario happens when the functional test teamctxinfra is invoked in `functional_tests/drivers.sh teamctxinfra`, that invokes the teamctxinfra tester with a different setup than `all` would do

` mpirun -n 2 -mca pml ucx -mca osc ucx -x ROCSHMEM_MAX_NUM_CONTEXTS=1 -x UCX_ROCM_IPC_SIGPOOL_MAX_ELEMS=16384 --map-by numa --timeout 300 tests/functional_tests/rocshmem_example_driver -a 38 -w 1 -z 1 -s 8`

notable difference is that `all` would pass `-x ROCSHMEM_MAX_NUM_CONTEXTS=1024`

This unexpected setup would exercise a bug in backends `create_ctx` where we would dereference `ctx->SetFence` during create when `ctx` is `nullptr`. 


In addition the ctxinfra tester would push back the nullptr ctx from the prior failed create into the freelist when calling free_ctx with a nullptr param, which would explode in an even more bizare way later, assert instead. 