### PR TITLE
use correct MPI initialization method

### DIFF
--- a/examples/rocshmem_init_attr_test.cc
+++ b/examples/rocshmem_init_attr_test.cc
@@ -61,6 +61,9 @@ int main (int argc, char **argv)
     int provided;
 
     MPI_Init_thread (&argc, &argv, MPI_THREAD_MULTIPLE, &provided);
+    if (provided != MPI_THREAD_MULTIPLE) {
+      std::cerr << "MPI_THREAD_MULTIPLE support disabled.\n";
+    }
     MPI_Comm_rank (MPI_COMM_WORLD, &world_rank);
     MPI_Comm_size (MPI_COMM_WORLD, &world_nranks);
 

--- a/examples/rocshmem_init_attr_test.cc
+++ b/examples/rocshmem_init_attr_test.cc
@@ -58,8 +58,9 @@ int main (int argc, char **argv)
     int ret;
     rocshmem_uniqueid_t uid;
     rocshmem_init_attr_t attr;
+    int provided;
 
-    MPI_Init(&argc, &argv);
+    MPI_Init_thread (&argc, &argv, MPI_THREAD_MULTIPLE, &provided);
     MPI_Comm_rank (MPI_COMM_WORLD, &world_rank);
     MPI_Comm_size (MPI_COMM_WORLD, &world_nranks);
 


### PR DESCRIPTION
rocSHMEM requires that the MPI library is initialized using THREAD_MULTIPLE support. Lets use that function therefore in our examples.