### PR TITLE
Verify data in GPU kernel for RMA ops

### DIFF
--- a/tests/functional_tests/primitive_tester.cpp
+++ b/tests/functional_tests/primitive_tester.cpp
@@ -181,13 +181,23 @@ void PrimitiveTester::verifyResults(uint64_t size) {
 
   if (args.myid == check_id) {
     size_t buff_size = size * args.wg_size * args.num_wgs;
-    for (uint64_t i = 0; i < buff_size; i++) {
-      if (dest[i] != source[i]) {
-        std::cerr << "Data validation error at idx " << i << std::endl;
-        std::cerr << " Got " << dest[i] << ", Expected "
-                  << source[i] << std::endl;
-        exit(-1);
+    size_t verify_wg_size = std::min((size_t) 1024, buff_size);
+    size_t verify_num_wgs = buff_size / verify_wg_size;
+
+    hipLaunchKernelGGL(verify_results_kernel_char, verify_num_wgs, verify_wg_size, 0, stream,
+                       source, dest, buff_size, verification_error);
+    CHECK_HIP(hipStreamSynchronize(stream));
+
+    if (*verification_error) {
+      for (uint64_t i = 0; i < buff_size; i++) {
+        if (dest[i] != source[i]) {
+          std::cerr << "Data validation error at idx " << i << std::endl;
+          std::cerr << " Got " << dest[i] << ", Expected "
+                    << source[i] << std::endl;
+          exit(-1);
+        }
       }
+      *verification_error = false;
     }
   }
 }

--- a/tests/functional_tests/tester.cpp
+++ b/tests/functional_tests/tester.cpp
@@ -83,6 +83,8 @@ Tester::Tester(TesterArguments args) : args(args) {
   CHECK_HIP(hipMalloc((void**)&timer, sizeof(long long int) * num_timers));
   CHECK_HIP(hipMalloc((void**)&start_time, sizeof(long long int) * num_timers));
   CHECK_HIP(hipMalloc((void**)&end_time, sizeof(long long int) * num_timers));
+  CHECK_HIP(hipHostMalloc((void**)&verification_error, sizeof(bool)));
+  *verification_error = false;
 }
 
 Tester::~Tester() {
@@ -92,6 +94,7 @@ Tester::~Tester() {
   CHECK_HIP(hipEventDestroy(stop_event));
   CHECK_HIP(hipEventDestroy(start_event));
   CHECK_HIP(hipStreamDestroy(stream));
+  CHECK_HIP(hipFree(verification_error));
 }
 
 std::vector<Tester*> Tester::create(TesterArguments args) {

--- a/tests/functional_tests/tester.hpp
+++ b/tests/functional_tests/tester.hpp
@@ -31,6 +31,7 @@
 
 #include "tester_arguments.hpp"
 #include "../src/util.hpp"
+#include "verify_results_kernels.hpp"
 
 /******************************************************************************
  * TESTER CLASS TYPES
@@ -161,6 +162,8 @@ class Tester {
   long long int min_start_time = 0;
   long long int max_end_time = 0;
   uint32_t num_timers = 0;
+
+  bool *verification_error;
 
  private:
   bool _print_header = 1;

--- a/tests/functional_tests/verify_results_kernels.hpp
+++ b/tests/functional_tests/verify_results_kernels.hpp
@@ -1,0 +1,46 @@
+/******************************************************************************
+ * Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ *****************************************************************************/
+
+#ifndef _VERIFY_RESULTS_KERNELS_HPP_
+#define _VERIFY_RESULTS_KERNELS_HPP_
+
+namespace rocshmem {
+
+static __global__ void verify_results_kernel_char(char *source, char *dest, size_t buf_size,
+                                                  bool *verification_error) {
+
+  int idx = get_flat_id();
+
+  if (idx >= buf_size) {
+    return;
+  }
+
+  if (dest[idx] != source[idx]) {
+    *verification_error = true;
+  }
+}
+
+}
+
+#endif /* _VERIFY_RESULTS_KERNELS_HPP_ */

--- a/tests/functional_tests/workgroup_primitives.cpp
+++ b/tests/functional_tests/workgroup_primitives.cpp
@@ -140,13 +140,23 @@ void WorkGroupPrimitiveTester::verifyResults(uint64_t size) {
 
   if (args.myid == check_id) {
     size_t buff_size = size * args.num_wgs;
-    for (size_t i = 0; i < buff_size; i++) {
-      if (dest[i] != source[i]) {
-        std::cerr << "Data validation error at idx " << i << std::endl;
-        std::cerr << " Got " << dest[i] << ", Expected "
-                  << source[i] << std::endl;
-        exit(-1);
+    size_t verify_wg_size = std::min((size_t) 1024, buff_size);
+    size_t verify_num_wgs = buff_size / verify_wg_size;
+
+    hipLaunchKernelGGL(verify_results_kernel_char, verify_num_wgs, verify_wg_size, 0, stream,
+                       source, dest, buff_size, verification_error);
+    CHECK_HIP(hipStreamSynchronize(stream));
+
+    if (*verification_error) {
+      for (size_t i = 0; i < buff_size; i++) {
+        if (dest[i] != source[i]) {
+          std::cerr << "Data validation error at idx " << i << std::endl;
+          std::cerr << " Got " << dest[i] << ", Expected "
+                    << source[i] << std::endl;
+          exit(-1);
+        }
       }
+      *verification_error = false;
     }
   }
 }


### PR DESCRIPTION
# What is in this PR?
- CI times can be long due to extensive testing
  - We currently verify our data in series on the host.
- In this PR we introduce parallel verification of our data with a GPU kernel for RMA ops
- 41% decrease in testing time for multi-node RMA ops

# Data
## Develop Branch (e3b0353fa9a4036eb001702fe417b07b03ce87ca)

```
time ../scripts/functional_tests/driver.sh ./tests/functional_tests/rocshmem_example_driver rma logs ../../hostfile.txt
put_n2_w1_z1_1048576B
put_n2_w1_z1024_512B
...

real	8m50.673s
user	17m49.843s
sys	1m10.562s
```

## This PR
```
time ../scripts/functional_tests/driver.sh ./tests/functional_tests/rocshmem_example_driver rma logs ../../hostfile.txt
put_n2_w1_z1_1048576B
put_n2_w1_z1024_512B
...

real	5m12.426s
user	10m14.829s
sys	1m8.757s
```
# Error Checking
If we get an error still get the original error output:
```
=============================================================
### Creating Test: Blocking Puts ###
Data validation error at idx 0
 Got z, Expected a
--------------------------------------------------------------------------
prterun detected that one or more processes exited with non-zero status,
thus causing the job to be terminated. The first process to do so was:

   Process name: [prterun-smc300x-ccs-aus-gpuf27b-2109810@1,1]
   Exit code:    255
--------------------------------------------------------------------------
```