### PR TITLE
rocSHMEM now compiles IPC and RO backends with default cmake command

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,11 +41,11 @@ endif()
 ###############################################################################
 option(DEBUG "Enable debug trace" OFF)
 option(PROFILE "Enable statistics and timing support" OFF)
-option(USE_RO "Enable RO conduit." ON)
+option(USE_RO "Enable RO conduit." OFF)
 option(USE_IPC "Enable IPC support (using HIP)" OFF)
 option(USE_THREADS "Enable workgroup threads to share network queues" OFF)
 option(USE_WF_COAL "Enable wavefront message coalescing" OFF)
-option(USE_COHERENT_HEAP "Enable support for coherent systems" OFF)
+option(USE_COHERENT_HEAP "Enable support for coherent systems" ON)
 option(USE_MANAGED_HEAP "Enable managed memory" OFF)
 option(USE_HOST_HEAP "Enable host memory using malloc/free" OFF)
 option(USE_HIP_HOST_HEAP "Enable host memory using hip api" OFF)
@@ -62,6 +62,10 @@ option(BUILD_SOS_TESTS "Build the host-facing tests" OFF)
 option(BUILD_UNIT_TESTS "Build the unit tests" ON)
 option(BUILD_TESTS_ONLY "Build only tests. Used to link agains rocSHMEM in a ROCm Release" OFF)
 
+option(BUILD_ROCSHMEM_IPC_LIB "Build librocshmem_ipc.a" ON)
+option(BUILD_ROCSHMEM_RO "Build librocshmem_ro.a (for debug purposes)" OFF)
+option(BUILD_ROCSHMEM_RO_IPC_LIB "Build librocshmem_ro_ipc.a" ON)
+
 option(BUILD_LOCAL_GPU_TARGET_ONLY "Build only for GPUs detected on this machine" OFF)
 
 configure_file(cmake/rocshmem_config.h.in rocshmem_config.h)
@@ -69,6 +73,14 @@ configure_file(cmake/rocshmem_config.h.in rocshmem_config.h)
 ###############################################################################
 # GLOBAL COMPILE FLAGS
 ###############################################################################
+
+
+if ((NOT BUILD_ROCSHMEM_IPC_LIB) AND
+    (NOT BUILD_ROCSHMEM_RO_LIB) AND
+    (NOT BUILD_ROCSHMEM_RO_IPC_LIB))
+  message(FATAL_ERROR "Neither IPC, RO, nor RO_IPC libraries were not selected.")
+endif()
+
 if (DEFINED ENV{ROCM_PATH})
   set(ROCM_PATH "$ENV{ROCM_PATH}" CACHE STRING "ROCm install directory")
 else()
@@ -98,12 +110,6 @@ set(ROCMCHECKS_WARN_TOOLCHAIN_VAR OFF)
 
 include(cmake/rocm_local_targets.cmake)
 
-set(DEFAULT_GPUS
-      gfx90a:xnack-;
-      gfx90a:xnack+;
-      gfx942:xnack-;
-      gfx942:xnack+)
-
 ###############################################################################
 # PROJECT
 ###############################################################################
@@ -115,98 +121,92 @@ include(ROCMCheckTargetIds)
 rocm_setup_version(VERSION 2.0.0)
 project(rocshmem VERSION 2.0.0 LANGUAGES CXX)
 
-###############################################################################
-# CREATE ROCSHMEM LIBRARY
-###############################################################################
-if (NOT BUILD_TESTS_ONLY)
-  add_library(${PROJECT_NAME})
-  add_library(roc::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
-  add_subdirectory(src)
+rocshmem_set_gpu_targets()
 
-  #############################################################################
-  # SET GPU ARCHITECTURES
-  #############################################################################
-  if (BUILD_LOCAL_GPU_TARGET_ONLY)
-    message(STATUS "Building only for local GPU target")
-    if (COMMAND rocm_local_targets)
-      rocm_local_targets(DEFAULT_GPUS)
-    else()
-      message(WARNING "Unable to determine local GPU targets. Falling back to default GPUs.")
-    endif()
-  endif()
+find_package(MPI REQUIRED)
+find_package(hip REQUIRED)
+find_package(hsa-runtime64 REQUIRED)
 
-  set(GPU_TARGETS "${DEFAULT_GPUS}" CACHE STRING
-      "Target default GPUs if GPU_TARGETS is not defined.")
+set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
+set(THREADS_PREFER_PTHREAD_FLAG TRUE)
+find_package(Threads REQUIRED)
 
-  if (COMMAND rocm_check_target_ids)
-    message(STATUS "Checking for ROCm support for GPU targets: " "${GPU_TARGETS}")
-    rocm_check_target_ids(SUPPORTED_GPUS TARGETS ${GPU_TARGETS})
-  else()
-    message(WARNING "Unable to check for supported GPU targets. Falling back to default GPUs.")
-    set(SUPPORTED_GPUS ${DEFAULT_GPUS})
-  endif()
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
-  set(COMPILING_TARGETS "${SUPPORTED_GPUS}" CACHE STRING "GPU targets to compile for.")
-  message(STATUS "Compiling for ${COMPILING_TARGETS}")
+include_directories(
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}>               # rocshmem_config.h
+  $<INSTALL_INTERFACE:include>
+  ${MPI_CXX_HEADER_DIR}
+)
 
-  foreach (target ${COMPILING_TARGETS})
-    list(APPEND offload_flags --offload-arch=${target})
-  endforeach()
-  add_compile_options(${offload_flags})
+link_libraries(
+  Threads::Threads
+  ${MPI_mpi_LIBRARY}
+  ${MPI_mpicxx_LIBRARY}
+  hip::device
+  hip::host
+  hsa-runtime64::hsa-runtime64
+  -fgpu-rdc
+)
 
-  #############################################################################
-  # PACKAGE DEPENDENCIES
-  #############################################################################
-  find_package(MPI REQUIRED)
-  find_package(hip REQUIRED)
-  find_package(hsa-runtime64 REQUIRED)
+add_compile_options("-fgpu-rdc")
 
-  set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
-  set(THREADS_PREFER_PTHREAD_FLAG TRUE)
-  find_package(Threads REQUIRED)
-
-  #############################################################################
-  # LINKING AND INCLUDE DIRECTORIES
-  #############################################################################
-  target_include_directories(
-    ${PROJECT_NAME}
-    PUBLIC
-      $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-      $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}>               # rocshmem_config.h
-      $<INSTALL_INTERFACE:include>
-      ${MPI_CXX_HEADER_DIR}
-  )
-
-  target_link_libraries(
-    ${PROJECT_NAME}
-    PUBLIC
-      Threads::Threads
-      ${MPI_mpi_LIBRARY}
-      ${MPI_mpicxx_LIBRARY}
-      hip::device
-      hip::host
-      hsa-runtime64::hsa-runtime64
+if (BUILD_TESTS_ONLY)
+  include_directories(
+    $<BUILD_INTERFACE:${ROCSHMEM_HOME}/include>
   )
 endif()
 
 ###############################################################################
-# TEST SUBDIRECTORIES
+# CREATE ROCSHMEM LIBRARY MACRO
 ###############################################################################
+
+macro(rocshmem_add_library ROCSHMEM_LIB_NAME EXTRA_FLAGS)
+  if (NOT BUILD_TESTS_ONLY)
+    add_library(${ROCSHMEM_LIB_NAME})
+    add_library(roc::${ROCSHMEM_LIB_NAME} ALIAS ${ROCSHMEM_LIB_NAME})
+
+    rocm_install(TARGETS ${ROCSHMEM_LIB_NAME})
+
+    rocm_export_targets(
+      TARGETS roc::${ROCSHMEM_LIB_NAME}
+      NAMESPACE roc::
+    )
+  endif()
+
+  list(APPEND ROCSHMEM_LIB_NAMES ${ROCSHMEM_LIB_NAME})
+endmacro()
+
+###############################################################################
+# CREATE ROCSHMEM LIBRARY
+###############################################################################
+if (BUILD_ROCSHMEM_IPC_LIB)
+  rocshmem_add_library(rocshmem "-DUSE_IPC=ON -DUSE_SINGLE_NODE=ON")
+endif()
+
+if (BUILD_ROCSHMEM_RO_LIB)
+    rocshmem_add_library(rocshmem_ro "-DUSE_RO=ON")
+endif()
+
+if (BUILD_ROCSHMEM_RO_IPC_LIB)
+  rocshmem_add_library(rocshmem_ro_ipc "-DUSE_RO=ON -DUSE_IPC=ON")
+endif()
+
+if (NOT BUILD_TESTS_ONLY)
+  add_subdirectory(src)
+endif()
+
 add_subdirectory(tests)
 
 if (BUILD_EXAMPLES)
   add_subdirectory(examples)
 endif()
 
+###############################################################################
+# INSTALL ROCSHMEM LIBRARY(S)
+###############################################################################
 if (NOT BUILD_TESTS_ONLY)
-  #############################################################################
-  # INSTALL
-  #############################################################################
-  include(ROCMInstallTargets)
-  include(ROCMCreatePackage)
-
-  rocm_install(TARGETS rocshmem)
-
   rocm_install(
     DIRECTORY ${CMAKE_SOURCE_DIR}/include/
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
@@ -222,11 +222,6 @@ if (NOT BUILD_TESTS_ONLY)
       hsa-rocr
       hip-runtime-amd
       rocm-dev
-  )
-
-  rocm_export_targets(
-    TARGETS roc::rocshmem
-    NAMESPACE roc::
   )
 
   rocm_create_package(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,8 +62,8 @@ option(BUILD_SOS_TESTS "Build the host-facing tests" OFF)
 option(BUILD_UNIT_TESTS "Build the unit tests" ON)
 option(BUILD_TESTS_ONLY "Build only tests. Used to link agains rocSHMEM in a ROCm Release" OFF)
 
-option(BUILD_ROCSHMEM_IPC_LIB "Build librocshmem_ipc.a" ON)
-option(BUILD_ROCSHMEM_RO "Build librocshmem_ro.a (for debug purposes)" OFF)
+option(BUILD_ROCSHMEM_IPC_LIB "Build librocshmem.a" ON)
+option(BUILD_ROCSHMEM_RO_LIB "Build librocshmem_ro.a (for debug purposes)" OFF)
 option(BUILD_ROCSHMEM_RO_IPC_LIB "Build librocshmem_ro_ipc.a" ON)
 
 option(BUILD_LOCAL_GPU_TARGET_ONLY "Build only for GPUs detected on this machine" OFF)
@@ -73,7 +73,6 @@ configure_file(cmake/rocshmem_config.h.in rocshmem_config.h)
 ###############################################################################
 # GLOBAL COMPILE FLAGS
 ###############################################################################
-
 
 if ((NOT BUILD_ROCSHMEM_IPC_LIB) AND
     (NOT BUILD_ROCSHMEM_RO_LIB) AND
@@ -167,6 +166,8 @@ macro(rocshmem_add_library ROCSHMEM_LIB_NAME EXTRA_FLAGS)
     add_library(${ROCSHMEM_LIB_NAME})
     add_library(roc::${ROCSHMEM_LIB_NAME} ALIAS ${ROCSHMEM_LIB_NAME})
 
+    target_compile_definitions(${ROCSHMEM_LIB_NAME} PRIVATE ${EXTRA_FLAGS})
+
     rocm_install(TARGETS ${ROCSHMEM_LIB_NAME})
 
     rocm_export_targets(
@@ -186,7 +187,7 @@ if (BUILD_ROCSHMEM_IPC_LIB)
 endif()
 
 if (BUILD_ROCSHMEM_RO_LIB)
-    rocshmem_add_library(rocshmem_ro "-DUSE_RO=ON")
+  rocshmem_add_library(rocshmem_ro "-DUSE_RO=ON")
 endif()
 
 if (BUILD_ROCSHMEM_RO_IPC_LIB)

--- a/cmake/rocm_local_targets.cmake
+++ b/cmake/rocm_local_targets.cmake
@@ -50,3 +50,42 @@ function(rocm_local_targets VARIABLE)
   endif()
 endfunction()
 
+#############################################################################
+# SET GPU ARCHITECTURES
+#############################################################################
+macro(rocshmem_set_gpu_targets)
+  set(DEFAULT_GPUS
+        gfx90a:xnack-;
+        gfx90a:xnack+;
+        gfx942:xnack-;
+        gfx942:xnack+)
+
+  if (BUILD_LOCAL_GPU_TARGET_ONLY)
+    message(STATUS "Building only for local GPU target")
+    if (COMMAND rocm_local_targets)
+      rocm_local_targets(DEFAULT_GPUS)
+    else()
+      message(WARNING "Unable to determine local GPU targets. Falling back to default GPUs.")
+    endif()
+  endif()
+
+  set(GPU_TARGETS "${DEFAULT_GPUS}" CACHE STRING
+      "Target default GPUs if GPU_TARGETS is not defined.")
+
+  if (COMMAND rocm_check_target_ids)
+    message(STATUS "Checking for ROCm support for GPU targets: " "${GPU_TARGETS}")
+    rocm_check_target_ids(SUPPORTED_GPUS TARGETS ${GPU_TARGETS})
+  else()
+    message(WARNING "Unable to check for supported GPU targets. Falling back to default GPUs.")
+    set(SUPPORTED_GPUS ${DEFAULT_GPUS})
+  endif()
+
+  set(COMPILING_TARGETS "${SUPPORTED_GPUS}" CACHE STRING "GPU targets to compile for.")
+  message(STATUS "Compiling for ${COMPILING_TARGETS}")
+
+  foreach (target ${COMPILING_TARGETS})
+    list(APPEND offload_flags --offload-arch=${target})
+  endforeach()
+  add_compile_options(${offload_flags})
+endmacro()
+

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -34,56 +34,26 @@ set(EXAMPLE_SOURCES
   rocshmem_init_attr_test.cc
 )
 
-foreach(SOURCE_FILE IN LISTS EXAMPLE_SOURCES)
-  get_filename_component(EXECUTABLE_NAME ${SOURCE_FILE} NAME_WE)
+foreach(ROCSHMEM_LIB_NAME IN LISTS ROCSHMEM_LIB_NAMES)
+  foreach(SOURCE_FILE IN LISTS EXAMPLE_SOURCES)
+    get_filename_component(EXECUTABLE_NAME ${SOURCE_FILE} NAME_WE)
+    string(REPLACE "rocshmem" "${ROCSHMEM_LIB_NAME}" EXECUTABLE_NAME ${EXECUTABLE_NAME})
 
-  add_executable(${EXECUTABLE_NAME} ${SOURCE_FILE})
+    add_executable(${EXECUTABLE_NAME} ${SOURCE_FILE})
 
-  if (BUILD_TESTS_ONLY)
-    find_package(MPI REQUIRED)
-
-    target_include_directories(
-      ${EXECUTABLE_NAME}
-      PRIVATE
-        $<BUILD_INTERFACE:${ROCSHMEM_HOME}/include>
-        $<BUILD_INTERFACE:${MPI_CXX_HEADER_DIR}>
-    )
-
-    foreach (target ${DEFAULT_GPUS})
-      list(APPEND offload_flags --offload-arch=${target})
-    endforeach()
-
-    target_compile_options(
-      ${EXECUTABLE_NAME}
-      PRIVATE
-        ${offload_flags}
-        -fgpu-rdc
-    )
-
-    target_link_libraries(
-      ${EXECUTABLE_NAME}
-      PRIVATE
-        ${MPI_mpi_LIBRARY}
-        ${MPI_mpicxx_LIBRARY}
-        ${offload_flags}
-        -L${ROCSHMEM_HOME}/lib
-        -lamdhip64
-        -lhsa-runtime64
-        -lrocshmem
-        -fgpu-rdc
-    )
-  else()
-    target_include_directories(
-      ${EXECUTABLE_NAME}
-      PRIVATE
-        roc::rocshmem
-    )
-
-    target_link_libraries(
-      ${EXECUTABLE_NAME}
-      PRIVATE
-        roc::rocshmem
-        -fgpu-rdc
-    )
-  endif()
+    if (BUILD_TESTS_ONLY)
+      target_link_libraries(
+        ${EXECUTABLE_NAME}
+        PRIVATE
+          -L${ROCSHMEM_HOME}/lib
+          -l${ROCSHMEM_LIB_NAME}
+      )
+    else()
+      target_link_libraries(
+        ${EXECUTABLE_NAME}
+        PRIVATE
+          roc::${ROCSHMEM_LIB_NAME}
+      )
+    endif()
+  endforeach()
 endforeach()

--- a/scripts/build_configs/build_tests_only
+++ b/scripts/build_configs/build_tests_only
@@ -40,23 +40,10 @@ fi
 
 src_path=$(dirname "$(realpath $0)")/../../
 
-cmake \
-    -DCMAKE_BUILD_TYPE=Release \
+cmake                                    \
+    -DCMAKE_BUILD_TYPE=Release           \
     -DCMAKE_INSTALL_PREFIX=$install_path \
-    -DCMAKE_VERBOSE_MAKEFILE=OFF \
-    -DDEBUG=OFF \
-    -DPROFILE=OFF \
-    -DUSE_RO=OFF \
-    -DUSE_IPC=ON \
-    -DUSE_COHERENT_HEAP=ON \
-    -DUSE_THREADS=OFF \
-    -DUSE_WF_COAL=OFF \
-    -DUSE_SINGLE_NODE=ON \
-    -DUSE_HOST_SIDE_HDP_FLUSH=OFF \
-    -DBUILD_LOCAL_GPU_TARGET_ONLY=OFF \
-    -DBUILD_TESTS_ONLY=ON \
-    -DBUILD_FUNCTIONAL_TESTS=ON \
-    -DBUILD_EXAMPLES=ON \
-    -DBUILD_UNIT_TESTS=OFF \
+    -DCMAKE_VERBOSE_MAKEFILE=OFF         \
+    -DBUILD_TESTS_ONLY=ON                \
     $src_path
 cmake --build . --parallel 8

--- a/scripts/build_configs/ipc_single
+++ b/scripts/build_configs/ipc_single
@@ -35,21 +35,16 @@ fi
 
 src_path=$(dirname "$(realpath $0)")/../../
 
-cmake \
-    -DCMAKE_BUILD_TYPE=Release \
+cmake                                    \
+    -DCMAKE_BUILD_TYPE=Release           \
     -DCMAKE_INSTALL_PREFIX=$install_path \
-    -DCMAKE_VERBOSE_MAKEFILE=OFF \
-    -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
-    -DDEBUG=OFF \
-    -DPROFILE=OFF \
-    -DUSE_RO=OFF \
-    -DUSE_IPC=ON \
-    -DUSE_COHERENT_HEAP=ON \
-    -DUSE_THREADS=OFF \
-    -DUSE_WF_COAL=OFF \
-    -DUSE_SINGLE_NODE=ON \
-    -DUSE_HOST_SIDE_HDP_FLUSH=OFF \
-    -DBUILD_LOCAL_GPU_TARGET_ONLY=OFF \
+    -DCMAKE_VERBOSE_MAKEFILE=OFF         \
+    -DBUILD_ROCSHMEM_IPC_LIB=ON          \
+    -DBUILD_ROCSHMEM_RO_IPC_LIB=OFF      \
     $src_path
 cmake --build . --parallel 8
 cmake --install .
+
+# CI Backwards Compatibility
+mv ./tests/functional_tests/rocshmem_functional_driver \
+   ./tests/functional_tests/rocshmem_example_driver

--- a/scripts/build_configs/ro_ipc
+++ b/scripts/build_configs/ro_ipc
@@ -35,20 +35,19 @@ fi
 
 src_path=$(dirname "$(realpath $0)")/../../
 
-cmake \
-    -DCMAKE_BUILD_TYPE=Release \
+cmake                                    \
+    -DCMAKE_BUILD_TYPE=Release           \
     -DCMAKE_INSTALL_PREFIX=$install_path \
-    -DCMAKE_VERBOSE_MAKEFILE=OFF \
-    -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
-    -DDEBUG=OFF \
-    -DPROFILE=OFF \
-    -DUSE_IPC=ON \
-    -DUSE_COHERENT_HEAP=ON \
-    -DUSE_THREADS=OFF \
-    -DUSE_WF_COAL=OFF \
-    -DUSE_HOST_SIDE_HDP_FLUSH=OFF\
-    -DUSE_MANAGED_HEAP=OFF \
-    -DUSE_RO=ON \
+    -DCMAKE_VERBOSE_MAKEFILE=OFF         \
+    -DBUILD_ROCSHMEM_RO_IPC_LIB=ON       \
+    -DBUILD_ROCSHMEM_IPC_LIB=OFF         \
     $src_path
 cmake --build . --parallel 8
 cmake --install .
+
+# CI Backwards Compatibility
+mv ./tests/functional_tests/rocshmem_ro_ipc_functional_driver \
+   ./tests/functional_tests/rocshmem_example_driver
+
+mv ./tests/unit_tests/rocshmem_ro_ipc_unit_tests \
+   ./tests/unit_tests/rocshmem_unit_tests

--- a/scripts/build_configs/ro_net
+++ b/scripts/build_configs/ro_net
@@ -41,7 +41,7 @@ cmake                                    \
     -DCMAKE_VERBOSE_MAKEFILE=OFF         \
     -DBUILD_ROCSHMEM_IPC_LIB=OFF         \
     -DBUILD_ROCSHMEM_RO_IPC_LIB=OFF      \
-    -DBUILD_ROCSHMEM_RO_LIB=OFF          \
+    -DBUILD_ROCSHMEM_RO_LIB=ON           \
     $src_path
 cmake --build . --parallel 8
 cmake --install .

--- a/scripts/build_configs/ro_net
+++ b/scripts/build_configs/ro_net
@@ -35,20 +35,20 @@ fi
 
 src_path=$(dirname "$(realpath $0)")/../../
 
-cmake \
-    -DCMAKE_BUILD_TYPE=Release \
+cmake                                    \
+    -DCMAKE_BUILD_TYPE=Release           \
     -DCMAKE_INSTALL_PREFIX=$install_path \
-    -DCMAKE_VERBOSE_MAKEFILE=OFF \
-    -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
-    -DDEBUG=OFF \
-    -DPROFILE=OFF \
-    -DUSE_IPC=OFF \
-    -DUSE_COHERENT_HEAP=ON \
-    -DUSE_THREADS=OFF \
-    -DUSE_WF_COAL=OFF \
-    -DUSE_HOST_SIDE_HDP_FLUSH=OFF\
-    -DUSE_MANAGED_HEAP=OFF \
-    -DUSE_RO=ON \
+    -DCMAKE_VERBOSE_MAKEFILE=OFF         \
+    -DBUILD_ROCSHMEM_IPC_LIB=OFF         \
+    -DBUILD_ROCSHMEM_RO_IPC_LIB=OFF      \
+    -DBUILD_ROCSHMEM_RO_LIB=OFF          \
     $src_path
 cmake --build . --parallel 8
 cmake --install .
+
+# CI Backwards Compatibility
+mv ./tests/functional_tests/rocshmem_ro_functional_driver \
+   ./tests/functional_tests/rocshmem_example_driver
+
+mv ./tests/unit_tests/rocshmem_ro_unit_tests \
+   ./tests/unit_tests/rocshmem_unit_tests

--- a/scripts/build_configs/ro_net_debug
+++ b/scripts/build_configs/ro_net_debug
@@ -35,19 +35,20 @@ fi
 
 src_path=$(dirname "$(realpath $0)")/../../
 
-cmake \
-    -DCMAKE_BUILD_TYPE=Debug \
+cmake                                    \
+    -DCMAKE_BUILD_TYPE=Debug             \
     -DCMAKE_INSTALL_PREFIX=$install_path \
-    -DCMAKE_VERBOSE_MAKEFILE=OFF \
-    -DDEBUG=OFF \
-    -DPROFILE=OFF \
-    -DUSE_IPC=OFF \
-    -DUSE_COHERENT_HEAP=ON \
-    -DUSE_THREADS=OFF \
-    -DUSE_WF_COAL=OFF \
-    -DUSE_HOST_SIDE_HDP_FLUSH=OFF\
-    -DUSE_MANAGED_HEAP=OFF \
-    -DUSE_RO=ON \
+    -DCMAKE_VERBOSE_MAKEFILE=OFF         \
+    -DBUILD_ROCSHMEM_IPC_LIB=OFF         \
+    -DBUILD_ROCSHMEM_RO_IPC_LIB=OFF      \
+    -DBUILD_ROCSHMEM_RO_LIB=OFF          \
     $src_path
 cmake --build . --parallel 8
 cmake --install .
+
+# CI Backwards Compatibility
+mv ./tests/functional_tests/rocshmem_ro_functional_driver \
+   ./tests/functional_tests/rocshmem_example_driver
+
+mv ./tests/unit_tests/rocshmem_ro_unit_tests \
+   ./tests/unit_tests/rocshmem_unit_tests

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -25,37 +25,30 @@
 ###############################################################################
 # ADD ROCSHMEM TARGET FOR FILES IN CURRENT DIRECTORY
 ###############################################################################
-target_sources(
-  ${PROJECT_NAME}
-  PRIVATE
-    atomic_return.cpp
-    backend_bc.cpp
-    context_host.cpp
-    context_device.cpp
-    mpi_init_singleton.cpp
-    rocshmem_gpu.cpp
-    rocshmem.cpp
-    team.cpp
-    team_tracker.cpp
-    util.cpp
-    wf_coal_policy.cpp
-    ipc_policy.cpp
-)
+foreach(ROCSHMEM_LIB_NAME IN LISTS ROCSHMEM_LIB_NAMES)
+  target_sources(
+    ${ROCSHMEM_LIB_NAME}
+    PRIVATE
+      atomic_return.cpp
+      backend_bc.cpp
+      context_host.cpp
+      context_device.cpp
+      mpi_init_singleton.cpp
+      rocshmem_gpu.cpp
+      rocshmem.cpp
+      team.cpp
+      team_tracker.cpp
+      util.cpp
+      wf_coal_policy.cpp
+      ipc_policy.cpp
+  )
 
-target_compile_options(
-  ${PROJECT_NAME}
-  PUBLIC
-    -fgpu-rdc
-#   xnack allows address translation fault recovery
-#   required option for managed heap configs
-#    -mxnack
-)
-
-#target_link_options(
-  #${PROJECT_NAME}
-  #PUBLIC
-    #--hip-link
-#)
+  target_compile_options(
+    ${ROCSHMEM_LIB_NAME}
+    PUBLIC
+      -fgpu-rdc
+  )
+endforeach()
 
 ###############################################################################
 # ROCSHMEM TARGET FOR BACKENDS

--- a/src/bootstrap/CMakeLists.txt
+++ b/src/bootstrap/CMakeLists.txt
@@ -25,10 +25,12 @@
 ###############################################################################
 # ADD ROCSHMEM TARGET FOR FILES IN CURRENT DIRECTORY
 ###############################################################################
-target_sources(
-  ${PROJECT_NAME}
-  PRIVATE
-    socket.cpp
-    bootstrap.cpp
-    utils.cpp
-)
+foreach(ROCSHMEM_LIB_NAME IN LISTS ROCSHMEM_LIB_NAMES)
+  target_sources(
+    ${ROCSHMEM_LIB_NAME}
+    PRIVATE
+      socket.cpp
+      bootstrap.cpp
+      utils.cpp
+  )
+endforeach()

--- a/src/containers/CMakeLists.txt
+++ b/src/containers/CMakeLists.txt
@@ -25,9 +25,11 @@
 ###############################################################################
 # ADD ROCSHMEM TARGET FOR FILES IN CURRENT DIRECTORY
 ###############################################################################
-target_sources(
-  ${PROJECT_NAME}
-  PRIVATE
-    share_strategy.cpp
-    strategies.cpp
-)
+foreach(ROCSHMEM_LIB_NAME IN LISTS ROCSHMEM_LIB_NAMES)
+  target_sources(
+    ${ROCSHMEM_LIB_NAME}
+    PRIVATE
+      share_strategy.cpp
+      strategies.cpp
+  )
+endforeach()

--- a/src/host/CMakeLists.txt
+++ b/src/host/CMakeLists.txt
@@ -25,8 +25,10 @@
 ###############################################################################
 # ADD ROCSHMEM TARGET FOR FILES IN CURRENT DIRECTORY
 ###############################################################################
-target_sources(
-  ${PROJECT_NAME}
-  PRIVATE
-    host.cpp
-)
+foreach(ROCSHMEM_LIB_NAME IN LISTS ROCSHMEM_LIB_NAMES)
+  target_sources(
+    ${ROCSHMEM_LIB_NAME}
+    PRIVATE
+      host.cpp
+  )
+endforeach()

--- a/src/ipc/CMakeLists.txt
+++ b/src/ipc/CMakeLists.txt
@@ -25,12 +25,14 @@
 ###############################################################################
 # ADD ROCSHMEM TARGET FOR FILES IN CURRENT DIRECTORY
 ###############################################################################
-target_sources(
-  ${PROJECT_NAME}
-  PRIVATE
-    context_ipc_device.cpp
-    context_ipc_host.cpp
-    backend_ipc.cpp
-    ipc_team.cpp
-    context_ipc_device_coll.cpp
-)
+foreach(ROCSHMEM_LIB_NAME IN LISTS ROCSHMEM_LIB_NAMES)
+  target_sources(
+    ${ROCSHMEM_LIB_NAME}
+    PRIVATE
+      context_ipc_device.cpp
+      context_ipc_host.cpp
+      backend_ipc.cpp
+      ipc_team.cpp
+      context_ipc_device_coll.cpp
+  )
+endforeach()

--- a/src/memory/CMakeLists.txt
+++ b/src/memory/CMakeLists.txt
@@ -25,10 +25,12 @@
 ###############################################################################
 # ADD ROCSHMEM TARGET FOR FILES IN CURRENT DIRECTORY
 ###############################################################################
-target_sources(
-  ${PROJECT_NAME}
-  PRIVATE
-    single_heap.cpp
-    memory_allocator.cpp
-    dlmalloc.cpp
-)
+foreach(ROCSHMEM_LIB_NAME IN LISTS ROCSHMEM_LIB_NAMES)
+  target_sources(
+    ${ROCSHMEM_LIB_NAME}
+    PRIVATE
+      single_heap.cpp
+      memory_allocator.cpp
+      dlmalloc.cpp
+  )
+endforeach()

--- a/src/reverse_offload/CMakeLists.txt
+++ b/src/reverse_offload/CMakeLists.txt
@@ -25,13 +25,15 @@
 ###############################################################################
 # ADD ROCSHMEM TARGET FOR FILES IN CURRENT DIRECTORY
 ###############################################################################
-target_sources(
-  ${PROJECT_NAME}
-  PRIVATE
-    backend_ro.cpp
-    context_ro_device.cpp
-    context_ro_host.cpp
-    mpi_transport.cpp
-    queue.cpp
-    ro_net_team.cpp
-)
+foreach(ROCSHMEM_LIB_NAME IN LISTS ROCSHMEM_LIB_NAMES)
+  target_sources(
+    ${ROCSHMEM_LIB_NAME}
+    PRIVATE
+      backend_ro.cpp
+      context_ro_device.cpp
+      context_ro_host.cpp
+      mpi_transport.cpp
+      queue.cpp
+      ro_net_team.cpp
+  )
+endforeach()

--- a/src/sync/CMakeLists.txt
+++ b/src/sync/CMakeLists.txt
@@ -25,8 +25,10 @@
 ###############################################################################
 # ADD ROCSHMEM TARGET FOR FILES IN CURRENT DIRECTORY
 ###############################################################################
-target_sources(
-  ${PROJECT_NAME}
-  PRIVATE
-    abql_block_mutex.cpp
-)
+foreach(ROCSHMEM_LIB_NAME IN LISTS ROCSHMEM_LIB_NAMES)
+  target_sources(
+    ${ROCSHMEM_LIB_NAME}
+    PRIVATE
+      abql_block_mutex.cpp
+  )
+endforeach()

--- a/tests/functional_tests/CMakeLists.txt
+++ b/tests/functional_tests/CMakeLists.txt
@@ -22,95 +22,70 @@
 # IN THE SOFTWARE.
 ###############################################################################
 
-set(TESTS_NAME rocshmem_example_driver)
+set(TESTS_NAME rocshmem_functional_driver)
 
-###############################################################################
-# SOURCES
-###############################################################################
-add_executable(${TESTS_NAME} "")
-
-target_include_directories(
-  ${TESTS_NAME}
-  PRIVATE
-    ${CMAKE_CURRENT_SOURCE_DIR}
-)
-
-target_sources(
-  ${TESTS_NAME}
-  PRIVATE
-    barrier_all_tester.cpp
-    sync_tester.cpp
-    test_driver.cpp
-    tester.cpp
-    tester_arguments.cpp
-    ping_pong_tester.cpp
-    ping_all_tester.cpp
-    primitive_tester.cpp
-    primitive_mr_tester.cpp
-    default_ctx_primitive_tester.cpp
-    team_ctx_primitive_tester.cpp
-    team_ctx_infra_tester.cpp
-    amo_bitwise_tester.cpp
-    amo_extended_tester.cpp
-    amo_standard_tester.cpp
-    random_access_tester.cpp
-    shmem_ptr_tester.cpp
-    signaling_operations_tester.cpp
-    signaling_operations_tester.hpp
-    workgroup_primitives.cpp
-    empty_tester.cpp
-    wavefront_primitives.cpp
-)
-
-###############################################################################
-# ROCSHMEM
-###############################################################################
-if (BUILD_TESTS_ONLY)
-  find_package(MPI REQUIRED)
+foreach(ROCSHMEM_LIB_NAME IN LISTS ROCSHMEM_LIB_NAMES)
+  ###############################################################################
+  # SOURCES
+  ###############################################################################
+  string(REPLACE "rocshmem" "${ROCSHMEM_LIB_NAME}" EXECUTABLE_NAME ${TESTS_NAME})
+  add_executable(${EXECUTABLE_NAME})
 
   target_include_directories(
-    ${TESTS_NAME}
+    ${EXECUTABLE_NAME}
     PRIVATE
-      $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/..>
-      $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}>
-      $<BUILD_INTERFACE:${ROCSHMEM_HOME}/include>
-      $<BUILD_INTERFACE:${MPI_CXX_HEADER_DIR}>
+      ${CMAKE_CURRENT_SOURCE_DIR}
   )
 
-  foreach (target ${DEFAULT_GPUS})
-    list(APPEND offload_flags --offload-arch=${target})
-  endforeach()
-
-  target_compile_options(
-    ${TESTS_NAME}
+  target_sources(
+    ${EXECUTABLE_NAME}
     PRIVATE
-      ${offload_flags}
-      -fgpu-rdc
+      barrier_all_tester.cpp
+      sync_tester.cpp
+      test_driver.cpp
+      tester.cpp
+      tester_arguments.cpp
+      ping_pong_tester.cpp
+      ping_all_tester.cpp
+      primitive_tester.cpp
+      primitive_mr_tester.cpp
+      default_ctx_primitive_tester.cpp
+      team_ctx_primitive_tester.cpp
+      team_ctx_infra_tester.cpp
+      amo_bitwise_tester.cpp
+      amo_extended_tester.cpp
+      amo_standard_tester.cpp
+      random_access_tester.cpp
+      shmem_ptr_tester.cpp
+      signaling_operations_tester.cpp
+      signaling_operations_tester.hpp
+      workgroup_primitives.cpp
+      empty_tester.cpp
+      wavefront_primitives.cpp
   )
 
-  target_link_libraries(
-    ${TESTS_NAME}
-    PRIVATE
-      ${MPI_mpi_LIBRARY}
-      ${MPI_mpicxx_LIBRARY}
-      ${offload_flags}
-      -L${ROCSHMEM_HOME}/lib
-      -lamdhip64
-      -lhsa-runtime64
-      -lrocshmem
-      -fgpu-rdc
-  )
-else()
-  target_include_directories(
-    ${TESTS_NAME}
-    PRIVATE
-      roc::rocshmem
-  )
+  ###############################################################################
+  # ROCSHMEM
+  ###############################################################################
+  if (BUILD_TESTS_ONLY)
+    target_include_directories(
+      ${EXECUTABLE_NAME}
+      PRIVATE
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/..>
+        $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}>
+    )
 
-  target_link_libraries(
-    ${TESTS_NAME}
-    PRIVATE
-      roc::rocshmem
-      -fgpu-rdc
-  )
-endif()
+    target_link_libraries(
+      ${EXECUTABLE_NAME}
+      PRIVATE
+        -L${ROCSHMEM_HOME}/lib
+        -l${ROCSHMEM_LIB_NAME}
+    )
+  else()
+    target_link_libraries(
+      ${EXECUTABLE_NAME}
+      PRIVATE
+        roc::${ROCSHMEM_LIB_NAME}
+    )
+  endif()
+endforeach()

--- a/tests/unit_tests/CMakeLists.txt
+++ b/tests/unit_tests/CMakeLists.txt
@@ -59,108 +59,6 @@ endif()
 project(rocshmem_unit_tests VERSION 1.0.0 LANGUAGES CXX)
 
 ###############################################################################
-# SOURCES
-###############################################################################
-add_executable(${PROJECT_NAME} "")
-
-target_include_directories(
-  ${PROJECT_NAME}
-  PRIVATE
-    ${CMAKE_CURRENT_SOURCE_DIR}
-    ${CMAKE_SOURCE_DIR}/../../library
-)
-
-target_sources(
-  ${PROJECT_NAME}
-  PRIVATE
-    shmem_gtest.cpp
-    heap_memory_gtest.cpp
-    hipmalloc_gtest.cpp
-    bin_gtest.cpp
-    binner_gtest.cpp
-    #bitwise_gtest.cpp # Test is disabled becasue of compilation errors
-    address_record_gtest.cpp
-    index_strategy_gtest.cpp
-    single_heap_gtest.cpp
-    symmetric_heap_gtest.cpp
-    pow2_bins_gtest.cpp
-    dlmalloc_gtest.cpp
-    remote_heap_info_gtest.cpp
-    mpi_init_singleton_gtest.cpp
-    abql_block_mutex_gtest.cpp
-    notifier_gtest.cpp
-    free_list_gtest.cpp
-    wavefront_size_gtest.cpp
-    atomic_wf_queue_gtest.cpp
-)
-
-if (USE_IPC)
-  target_sources(
-    ${PROJECT_NAME}
-    PRIVATE
-      ipc_impl_simple_coarse_gtest.cpp
-      ipc_impl_simple_fine_gtest.cpp
-      ipc_impl_tiled_fine_gtest.cpp
-  )
-endif()
-
-###############################################################################
-# ROCSHMEM DEPENDENCY
-###############################################################################
-find_package(hip REQUIRED)
-
-if (BUILD_TESTS_ONLY)
-  find_package(MPI REQUIRED)
-
-  target_include_directories(
-    ${PROJECT_NAME}
-    PRIVATE
-      $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/..>
-      $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}>
-      $<BUILD_INTERFACE:${ROCSHMEM_HOME}/include>
-      $<BUILD_INTERFACE:${MPI_CXX_HEADER_DIR}>
-  )
-
-  foreach (target ${DEFAULT_GPUS})
-    list(APPEND offload_flags --offload-arch=${target})
-  endforeach()
-
-  target_compile_options(
-    ${PROJECT_NAME}
-    PRIVATE
-      ${offload_flags}
-      -fgpu-rdc
-  )
-
-  target_link_libraries(
-    ${PROJECT_NAME}
-    PRIVATE
-      ${MPI_mpi_LIBRARY}
-      ${MPI_mpicxx_LIBRARY}
-      ${offload_flags}
-      -L${ROCSHMEM_HOME}/lib
-      -lamdhip64
-      -lhsa-runtime64
-      -lrocshmem
-      -fgpu-rdc
-  )
-else()
-  target_include_directories(
-    ${PROJECT_NAME}
-    PRIVATE
-      roc::rocshmem
-  )
-
-  target_link_libraries(
-    ${PROJECT_NAME}
-    PRIVATE
-      roc::rocshmem
-      hip::host
-      -fgpu-rdc
-  )
-endif()
-
-###############################################################################
 # GTEST DEPENDENCY
 ###############################################################################
 # These packages are required for the unit tests
@@ -182,10 +80,80 @@ set(BUILD_GTEST ON CACHE BOOL "" FORCE)
 
 FetchContent_MakeAvailable(googletest)
 
-target_link_libraries(
-  ${PROJECT_NAME}
-  PRIVATE
-    gtest
-    gtest_main
-    roc::rocthrust
-)
+foreach(ROCSHMEM_LIB_NAME IN LISTS ROCSHMEM_LIB_NAMES)
+  ###############################################################################
+  # SOURCES
+  ###############################################################################
+  string(REPLACE "rocshmem" "${ROCSHMEM_LIB_NAME}" EXECUTABLE_NAME ${PROJECT_NAME})
+  add_executable(${EXECUTABLE_NAME} "")
+
+  target_include_directories(
+    ${EXECUTABLE_NAME}
+    PRIVATE
+      ${CMAKE_CURRENT_SOURCE_DIR}
+      ${CMAKE_SOURCE_DIR}/../../library
+  )
+
+  target_sources(
+    ${EXECUTABLE_NAME}
+    PRIVATE
+      shmem_gtest.cpp
+      heap_memory_gtest.cpp
+      hipmalloc_gtest.cpp
+      bin_gtest.cpp
+      binner_gtest.cpp
+      #bitwise_gtest.cpp # Test is disabled becasue of compilation errors
+      address_record_gtest.cpp
+      index_strategy_gtest.cpp
+      single_heap_gtest.cpp
+      symmetric_heap_gtest.cpp
+      pow2_bins_gtest.cpp
+      dlmalloc_gtest.cpp
+      remote_heap_info_gtest.cpp
+      mpi_init_singleton_gtest.cpp
+      abql_block_mutex_gtest.cpp
+      notifier_gtest.cpp
+      free_list_gtest.cpp
+      wavefront_size_gtest.cpp
+      atomic_wf_queue_gtest.cpp
+  )
+
+  if (USE_IPC)
+    target_sources(
+      ${EXECUTABLE_NAME}
+      PRIVATE
+        ipc_impl_simple_coarse_gtest.cpp
+        ipc_impl_simple_fine_gtest.cpp
+        ipc_impl_tiled_fine_gtest.cpp
+    )
+  endif()
+
+  ###############################################################################
+  # ROCSHMEM DEPENDENCY
+  ###############################################################################
+
+  if (BUILD_TESTS_ONLY)
+    target_link_libraries(
+      ${EXECUTABLE_NAME}
+      PRIVATE
+        -L${ROCSHMEM_HOME}/lib
+        -l${ROCSHMEM_LIB_NAME}
+    )
+  else()
+    target_link_libraries(
+      ${EXECUTABLE_NAME}
+      PRIVATE
+        roc::${ROCSHMEM_LIB_NAME}
+    )
+  endif()
+
+  target_link_libraries(
+    ${EXECUTABLE_NAME}
+    PRIVATE
+      gtest
+      gtest_main
+      roc::rocthrust
+  )
+endforeach()
+
+


### PR DESCRIPTION
# Problem
- For each backend we have a separate script for that configuration.
- To fit in with ROCm-CI we need a single cmake command (`cmake ../`) that will compile the different backends