### PR TITLE
Fix several bugs of gda_devel branch

### DIFF
--- a/src/gpu_ib/network_policy.cpp
+++ b/src/gpu_ib/network_policy.cpp
@@ -93,11 +93,12 @@ void NetworkImpl::heap_memory_rkey(char *local_heap_base, size_t heap_size, MPI_
   lkey = heap_mr->lkey;
 }
 
-void NetworkImpl::setup_gpu_qps(GPUIBBackend *backend) {
+void NetworkImpl::setup_gpu_qps() {
   int connections = connection->total_number_connections();
   CHECK_HIP(hipMalloc(&gpu_qps, sizeof(QueuePair) * connections));
   for (int i{0}; i < connections; i++) {
-    new (&gpu_qps[i]) QueuePair(connection->ib_state->pd);
+    QueuePair qp(connection->ib_state->pd);
+    CHECK_HIP(hipMemcpy(&gpu_qps[i], &qp, sizeof(QueuePair), hipMemcpyDefault));
     connection->init_gpu_qp_from_connection(&gpu_qps[i], i);
   }
 }
@@ -110,7 +111,7 @@ void NetworkImpl::networkHostSetup(GPUIBBackend *backend) {
   connection->initialize(num_contexts);
   const auto &heap_bases{backend->heap.get_heap_bases()};
   heap_memory_rkey(heap_bases[my_pe], backend->heap.get_size(), backend->thread_comm);
-  setup_gpu_qps(backend);
+  setup_gpu_qps();
 }
 
 void NetworkImpl::networkHostFinalize() {
@@ -129,7 +130,7 @@ void NetworkImpl::networkHostInit(GPUIBContext *ctx, int context_id) {
   CHECK_HIP(hipMemset(ctx->device_qp_proxy, 0, sizeof(QueuePair) * num_pes));
   for (int i{0}; i < num_pes; i++) {
     int offset = num_pes * context_id + i;
-    new (ctx->getQueuePair(i)) QueuePair(gpu_qps[offset]);
+    CHECK_HIP(hipMemcpy(ctx->getQueuePair(i), &gpu_qps[offset], sizeof(QueuePair), hipMemcpyDefault));
     auto *qp = ctx->getQueuePair(i);
     qp->base_heap = ctx->base_heap;
   }

--- a/src/gpu_ib/network_policy.hpp
+++ b/src/gpu_ib/network_policy.hpp
@@ -79,7 +79,7 @@ class NetworkImpl {
    *
    * Upon completion, the gpu_qps member will be initialized.
    */
-  void setup_gpu_qps(GPUIBBackend *backend);
+  void setup_gpu_qps();
 
   /**
    * @brief The backend delegates some InfiniBand connection setup to

--- a/src/gpu_ib/queue_pair.cpp
+++ b/src/gpu_ib/queue_pair.cpp
@@ -59,7 +59,7 @@ __device__ void QueuePair::ring_doorbell(uint64_t db_val, uint64_t my_sq_counter
   __atomic_signal_fence(__ATOMIC_SEQ_CST);
 
   __hip_atomic_store(db.ptr, db_val, __ATOMIC_SEQ_CST, __HIP_MEMORY_SCOPE_SYSTEM);
-  uint64_t db_uint = __hip_atomic_load(&db.uint, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+  uint64_t db_uint = __hip_atomic_load(&db.uint, __ATOMIC_SEQ_CST, __HIP_MEMORY_SCOPE_AGENT);
   db_uint ^= 0x100;
   __hip_atomic_store(&db.uint, db_uint, __ATOMIC_SEQ_CST, __HIP_MEMORY_SCOPE_AGENT);
 }
@@ -81,9 +81,9 @@ __device__ void QueuePair::quiet() {
     uint64_t quiet_amount{0};
     uint64_t wave_cq_consumer{0};
     while (!done) {
-      uint64_t posted = __hip_atomic_load(&quiet_posted, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
-      uint64_t active = __hip_atomic_load(&quiet_active, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
-      uint64_t completed = __hip_atomic_load(&quiet_completed, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+      uint64_t posted = __hip_atomic_load(&quiet_posted, __ATOMIC_SEQ_CST, __HIP_MEMORY_SCOPE_AGENT);
+      uint64_t active = __hip_atomic_load(&quiet_active, __ATOMIC_SEQ_CST, __HIP_MEMORY_SCOPE_AGENT);
+      uint64_t completed = __hip_atomic_load(&quiet_completed, __ATOMIC_SEQ_CST, __HIP_MEMORY_SCOPE_AGENT);
       if (!(posted - completed)) {
         return;
       }
@@ -93,9 +93,9 @@ __device__ void QueuePair::quiet() {
       }
       quiet_amount = min(num_active_lanes, quiet_val);
       if (is_leader) {
-        done = __hip_atomic_compare_exchange_strong(&quiet_active, &active, active + quiet_amount, __ATOMIC_RELAXED, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+        done = __hip_atomic_compare_exchange_strong(&quiet_active, &active, active + quiet_amount, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST, __HIP_MEMORY_SCOPE_AGENT);
         if (done) {
-          wave_cq_consumer = __hip_atomic_fetch_add(&cq_consumer, quiet_amount, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+          wave_cq_consumer = __hip_atomic_fetch_add(&cq_consumer, quiet_amount, __ATOMIC_SEQ_CST, __HIP_MEMORY_SCOPE_AGENT);
         }
       }
       done = __shfl(done, leader_phys_lane_id);
@@ -125,7 +125,7 @@ __device__ void QueuePair::quiet() {
       uint16_t wqe_counter;
       swap_endian_store(const_cast<uint16_t*>(&wqe_counter), reinterpret_cast<uint16_t>(be_wqe_counter));
       uint64_t wqe_id =  outstanding_wqes[wqe_counter];
-      __hip_atomic_fetch_max(&wqe_broadcast[wavefront_id], wqe_id, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_WORKGROUP);
+      __hip_atomic_fetch_max(&wqe_broadcast[wavefront_id], wqe_id, __ATOMIC_SEQ_CST, __HIP_MEMORY_SCOPE_WORKGROUP);
       uint8_t mlx5_invld_bits = MLX5_CQE_INVALID << 4 | owner_bit;
       *((volatile uint8_t*)&cqe_entry->op_own) = mlx5_invld_bits;
       __atomic_signal_fence(__ATOMIC_SEQ_CST);
@@ -133,7 +133,7 @@ __device__ void QueuePair::quiet() {
     if (is_leader) {
       uint64_t completed {0};
       do {
-        completed = __hip_atomic_load(&quiet_completed, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+        completed = __hip_atomic_load(&quiet_completed, __ATOMIC_SEQ_CST, __HIP_MEMORY_SCOPE_AGENT);
       } while (completed != wave_cq_consumer);
 
       swap_endian_store(const_cast<uint32_t*>(cq_dbrec), (uint32_t)(wave_cq_consumer + quiet_amount));
@@ -156,15 +156,15 @@ __device__ void QueuePair::post_wqe_rma(int pe, int32_t size, uintptr_t *laddr, 
   uint64_t wave_sq_counter{0};
 
   if (is_leader) {
-    wave_sq_counter = __hip_atomic_fetch_add(&sq_posted, num_wqes, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+    wave_sq_counter = __hip_atomic_fetch_add(&sq_posted, num_wqes, __ATOMIC_SEQ_CST, __HIP_MEMORY_SCOPE_AGENT);
   }
   wave_sq_counter = __shfl(wave_sq_counter, leader_phys_lane_id);
   uint64_t my_sq_counter = wave_sq_counter + my_logical_lane_id;
   uint64_t my_sq_index = my_sq_counter % sq_wqe_cnt;
 
   while (true) {
-    uint64_t db_touched = __hip_atomic_load(&sq_db_touched, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
-    uint64_t sunk = __hip_atomic_load(&sq_sunk, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+    uint64_t db_touched = __hip_atomic_load(&sq_db_touched, __ATOMIC_SEQ_CST, __HIP_MEMORY_SCOPE_AGENT);
+    uint64_t sunk = __hip_atomic_load(&sq_sunk, __ATOMIC_SEQ_CST, __HIP_MEMORY_SCOPE_AGENT);
     uint64_t num_active_sq_entries = db_touched - sunk;
     uint64_t num_free_entries = min(sq_wqe_cnt, cq_cnt) - num_active_sq_entries;
     uint64_t num_entries_until_wave_last_entry = wave_sq_counter + num_active_lanes - db_touched;
@@ -185,7 +185,7 @@ __device__ void QueuePair::post_wqe_rma(int pe, int32_t size, uintptr_t *laddr, 
   if (is_leader) {
     uint64_t db_touched {0};
     do {
-      db_touched = __hip_atomic_load(&sq_db_touched, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+      db_touched = __hip_atomic_load(&sq_db_touched, __ATOMIC_SEQ_CST, __HIP_MEMORY_SCOPE_AGENT);
     } while (db_touched != wave_sq_counter);
 
     uint8_t *base_ptr = reinterpret_cast<uint8_t*>(sq_buf);
@@ -207,15 +207,15 @@ __device__ uint64_t QueuePair::post_wqe_amo(int pe, int32_t size, uintptr_t *rad
   uint64_t wave_sq_counter{0};
 
   if (is_leader) {
-    wave_sq_counter = __hip_atomic_fetch_add(&sq_posted, num_wqes, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+    wave_sq_counter = __hip_atomic_fetch_add(&sq_posted, num_wqes, __ATOMIC_SEQ_CST, __HIP_MEMORY_SCOPE_AGENT);
   }
   wave_sq_counter = __shfl(wave_sq_counter, leader_phys_lane_id);
   uint64_t my_sq_counter = wave_sq_counter + my_logical_lane_id;
   uint64_t my_sq_index = my_sq_counter % sq_wqe_cnt;
 
   while (true) {
-    uint64_t db_touched = __hip_atomic_load(&sq_db_touched, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
-    uint64_t sunk = __hip_atomic_load(&sq_sunk, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+    uint64_t db_touched = __hip_atomic_load(&sq_db_touched, __ATOMIC_SEQ_CST, __HIP_MEMORY_SCOPE_AGENT);
+    uint64_t sunk = __hip_atomic_load(&sq_sunk, __ATOMIC_SEQ_CST, __HIP_MEMORY_SCOPE_AGENT);
     uint64_t num_active_sq_entries = db_touched - sunk;
     uint64_t num_free_entries = min(sq_wqe_cnt, cq_cnt) - num_active_sq_entries;
     uint64_t num_entries_until_wave_last_entry = wave_sq_counter + num_active_lanes - db_touched;
@@ -253,7 +253,7 @@ __device__ uint64_t QueuePair::post_wqe_amo(int pe, int32_t size, uintptr_t *rad
   if (is_leader) {
     uint64_t db_touched {0};
     do {
-      db_touched = __hip_atomic_load(&sq_db_touched, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+      db_touched = __hip_atomic_load(&sq_db_touched, __ATOMIC_SEQ_CST, __HIP_MEMORY_SCOPE_AGENT);
     } while (db_touched != wave_sq_counter);
 
     uint8_t *base_ptr = reinterpret_cast<uint8_t*>(sq_buf);

--- a/src/gpu_ib/queue_pair.cpp
+++ b/src/gpu_ib/queue_pair.cpp
@@ -52,8 +52,8 @@ QueuePair::QueuePair(struct ibv_pd* pd) {
   }
 }
 
-__device__ void QueuePair::ring_doorbell(uint64_t db_val, uint32_t my_sq_counter) {
-  swap_endian_store(const_cast<uint32_t*>(dbrec), my_sq_counter);
+__device__ void QueuePair::ring_doorbell(uint64_t db_val, uint64_t my_sq_counter) {
+  swap_endian_store(const_cast<uint32_t*>(dbrec), (uint32_t)my_sq_counter);
   __atomic_signal_fence(__ATOMIC_SEQ_CST);
 
   __hip_atomic_store(db.ptr, db_val, __ATOMIC_SEQ_CST, __HIP_MEMORY_SCOPE_SYSTEM);
@@ -64,7 +64,7 @@ __device__ void QueuePair::ring_doorbell(uint64_t db_val, uint32_t my_sq_counter
 
 __device__ void QueuePair::quiet() {
   constexpr size_t BROADCAST_SIZE = 1024 / __AMDGCN_WAVEFRONT_SIZE;
-  __shared__ uint32_t wqe_broadcast[BROADCAST_SIZE];
+  __shared__ uint64_t wqe_broadcast[BROADCAST_SIZE];
   uint8_t wavefront_id = get_flat_block_id() / __AMDGCN_WAVEFRONT_SIZE;
   wqe_broadcast[wavefront_id] = 0;
 
@@ -76,16 +76,16 @@ __device__ void QueuePair::quiet() {
 
   while (true) {
     bool done{false};
-    uint32_t quiet_amount{0};
-    uint32_t wave_cq_consumer{0};
+    uint64_t quiet_amount{0};
+    uint64_t wave_cq_consumer{0};
     while (!done) {
-      uint32_t posted = __hip_atomic_load(&quiet_posted, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
-      uint32_t active = __hip_atomic_load(&quiet_active, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
-      uint32_t completed = __hip_atomic_load(&quiet_completed, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+      uint64_t posted = __hip_atomic_load(&quiet_posted, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+      uint64_t active = __hip_atomic_load(&quiet_active, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+      uint64_t completed = __hip_atomic_load(&quiet_completed, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
       if (!(posted - completed)) {
         return;
       }
-      uint32_t quiet_val = posted - active;
+      uint64_t quiet_val = posted - active;
       if (!quiet_val) {
         continue;
       }
@@ -99,8 +99,8 @@ __device__ void QueuePair::quiet() {
       done = __shfl(done, leader_phys_lane_id);
     }
     wave_cq_consumer = __shfl(wave_cq_consumer, leader_phys_lane_id);
-    uint32_t my_cq_consumer = wave_cq_consumer + my_logical_lane_id;
-    uint32_t my_cq_index = my_cq_consumer % cq_cnt;
+    uint64_t my_cq_consumer = wave_cq_consumer + my_logical_lane_id;
+    uint64_t my_cq_index = my_cq_consumer % cq_cnt;
 
     if (my_logical_lane_id < quiet_amount) {
       volatile mlx5_cqe64 *cqe_entry = &cq_buf[my_cq_index];
@@ -122,14 +122,14 @@ __device__ void QueuePair::quiet() {
 
       uint16_t wqe_counter;
       swap_endian_store(const_cast<uint16_t*>(&wqe_counter), reinterpret_cast<uint16_t>(be_wqe_counter));
-      uint32_t wqe_id =  outstanding_wqes[wqe_counter];
+      uint64_t wqe_id =  outstanding_wqes[wqe_counter];
       __hip_atomic_fetch_max(&wqe_broadcast[wavefront_id], wqe_id, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_WORKGROUP);
       uint8_t mlx5_invld_bits = MLX5_CQE_INVALID << 4 | owner_bit;
       *((volatile uint8_t*)&cqe_entry->op_own) = mlx5_invld_bits;
       __atomic_signal_fence(__ATOMIC_SEQ_CST);
     }
     if (is_leader) {
-      uint32_t completed {0};
+      uint64_t completed {0};
       do {
         completed = __hip_atomic_load(&quiet_completed, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
       } while (completed != wave_cq_consumer);
@@ -137,7 +137,7 @@ __device__ void QueuePair::quiet() {
       swap_endian_store(const_cast<uint32_t*>(cq_dbrec), (uint32_t)(wave_cq_consumer + quiet_amount));
       __atomic_signal_fence(__ATOMIC_SEQ_CST);
 
-      uint32_t sunk_wqe_id = wqe_broadcast[wavefront_id];
+      uint64_t sunk_wqe_id = wqe_broadcast[wavefront_id];
       __hip_atomic_store(&sq_sunk, sunk_wqe_id, __ATOMIC_SEQ_CST, __HIP_MEMORY_SCOPE_AGENT);
       __hip_atomic_fetch_add(&quiet_completed, quiet_amount, __ATOMIC_SEQ_CST, __HIP_MEMORY_SCOPE_AGENT);
     }
@@ -151,21 +151,21 @@ __device__ void QueuePair::post_wqe_rma(int pe, int32_t size, uintptr_t *laddr, 
   bool is_leader{my_logical_lane_id == 0};
   const uint64_t leader_phys_lane_id = __ffsll((unsigned long long)activemask) - 1;
   uint8_t num_wqes{num_active_lanes};
-  uint32_t wave_sq_counter{0};
+  uint64_t wave_sq_counter{0};
 
   if (is_leader) {
     wave_sq_counter = __hip_atomic_fetch_add(&sq_posted, num_wqes, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
   }
   wave_sq_counter = __shfl(wave_sq_counter, leader_phys_lane_id);
-  uint32_t my_sq_counter = wave_sq_counter + my_logical_lane_id;
-  uint32_t my_sq_index = my_sq_counter % sq_wqe_cnt;
+  uint64_t my_sq_counter = wave_sq_counter + my_logical_lane_id;
+  uint64_t my_sq_index = my_sq_counter % sq_wqe_cnt;
 
   while (true) {
-    uint32_t db_touched = __hip_atomic_load(&sq_db_touched, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
-    uint32_t sunk = __hip_atomic_load(&sq_sunk, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
-    uint32_t num_active_sq_entries = db_touched - sunk;
-    uint32_t num_free_entries = min(sq_wqe_cnt, cq_cnt) - num_active_sq_entries;
-    uint32_t num_entries_until_wave_last_entry = wave_sq_counter + num_active_lanes - db_touched;
+    uint64_t db_touched = __hip_atomic_load(&sq_db_touched, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+    uint64_t sunk = __hip_atomic_load(&sq_sunk, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+    uint64_t num_active_sq_entries = db_touched - sunk;
+    uint64_t num_free_entries = min(sq_wqe_cnt, cq_cnt) - num_active_sq_entries;
+    uint64_t num_entries_until_wave_last_entry = wave_sq_counter + num_active_lanes - db_touched;
     if (num_free_entries > num_entries_until_wave_last_entry) {
       break;
     }
@@ -181,7 +181,7 @@ __device__ void QueuePair::post_wqe_rma(int pe, int32_t size, uintptr_t *laddr, 
   __atomic_signal_fence(__ATOMIC_SEQ_CST);
 
   if (is_leader) {
-    uint32_t db_touched {0};
+    uint64_t db_touched {0};
     do {
       db_touched = __hip_atomic_load(&sq_db_touched, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
     } while (db_touched != wave_sq_counter);
@@ -202,21 +202,21 @@ __device__ uint64_t QueuePair::post_wqe_amo(int pe, int32_t size, uintptr_t *rad
   bool is_leader{my_logical_lane_id == 0};
   const uint64_t leader_phys_lane_id = __ffsll((unsigned long long)activemask) - 1;
   uint8_t num_wqes{num_active_lanes};
-  uint32_t wave_sq_counter{0};
+  uint64_t wave_sq_counter{0};
 
   if (is_leader) {
     wave_sq_counter = __hip_atomic_fetch_add(&sq_posted, num_wqes, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
   }
   wave_sq_counter = __shfl(wave_sq_counter, leader_phys_lane_id);
-  uint32_t my_sq_counter = wave_sq_counter + my_logical_lane_id;
-  uint32_t my_sq_index = my_sq_counter % sq_wqe_cnt;
+  uint64_t my_sq_counter = wave_sq_counter + my_logical_lane_id;
+  uint64_t my_sq_index = my_sq_counter % sq_wqe_cnt;
 
   while (true) {
-    uint32_t db_touched = __hip_atomic_load(&sq_db_touched, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
-    uint32_t sunk = __hip_atomic_load(&sq_sunk, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
-    uint32_t num_active_sq_entries = db_touched - sunk;
-    uint32_t num_free_entries = min(sq_wqe_cnt, cq_cnt) - num_active_sq_entries;
-    uint32_t num_entries_until_wave_last_entry = wave_sq_counter + num_active_lanes - db_touched;
+    uint64_t db_touched = __hip_atomic_load(&sq_db_touched, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+    uint64_t sunk = __hip_atomic_load(&sq_sunk, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+    uint64_t num_active_sq_entries = db_touched - sunk;
+    uint64_t num_free_entries = min(sq_wqe_cnt, cq_cnt) - num_active_sq_entries;
+    uint64_t num_entries_until_wave_last_entry = wave_sq_counter + num_active_lanes - db_touched;
     if (num_free_entries > num_entries_until_wave_last_entry) {
       break;
     }
@@ -249,7 +249,7 @@ __device__ uint64_t QueuePair::post_wqe_amo(int pe, int32_t size, uintptr_t *rad
   __atomic_signal_fence(__ATOMIC_SEQ_CST);
 
   if (is_leader) {
-    uint32_t db_touched {0};
+    uint64_t db_touched {0};
     do {
       db_touched = __hip_atomic_load(&sq_db_touched, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
     } while (db_touched != wave_sq_counter);

--- a/src/gpu_ib/queue_pair.cpp
+++ b/src/gpu_ib/queue_pair.cpp
@@ -34,12 +34,14 @@ namespace rocshmem {
 
 QueuePair::QueuePair(struct ibv_pd* pd) {
   allocator.allocate((void**)&nonfetching_atomic, 8);
+  CHECK_HIP(hipMemset(nonfetching_atomic, 0, 8));
   int access = IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE | IBV_ACCESS_REMOTE_READ | IBV_ACCESS_REMOTE_ATOMIC;
   ibv_mr *mr = ibv_reg_mr(pd, nonfetching_atomic, 8, access);
   GPUIB_CHECK_NNULL(mr, "ibv_reg_mr");
   nonfetching_atomic_lkey = htobe32(mr->lkey);
 
   allocator.allocate((void**)&fetching_atomic, 8 * FETCHING_ATOMIC_CNT);
+  CHECK_HIP(hipMemset(fetching_atomic, 0, 8 * FETCHING_ATOMIC_CNT));
   access = IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE | IBV_ACCESS_REMOTE_READ | IBV_ACCESS_REMOTE_ATOMIC;
   mr = ibv_reg_mr(pd, fetching_atomic, 8 * FETCHING_ATOMIC_CNT, access);
   GPUIB_CHECK_NNULL(mr, "ibv_reg_mr");

--- a/src/gpu_ib/queue_pair.cpp
+++ b/src/gpu_ib/queue_pair.cpp
@@ -192,8 +192,9 @@ __device__ void QueuePair::post_wqe_rma(int pe, int32_t size, uintptr_t *laddr, 
     uint64_t* ctrl_wqe_8B_for_db = reinterpret_cast<uint64_t*>(&base_ptr[64 * ((wave_sq_counter + num_wqes - 1) % sq_wqe_cnt)]);
     ring_doorbell(*ctrl_wqe_8B_for_db, wave_sq_counter + num_wqes);
 
-    __hip_atomic_fetch_add(&quiet_posted, num_wqes, __ATOMIC_SEQ_CST, __HIP_MEMORY_SCOPE_AGENT);
-    __hip_atomic_store(&sq_db_touched, wave_sq_counter + num_wqes, __ATOMIC_SEQ_CST, __HIP_MEMORY_SCOPE_AGENT);
+    uint64_t posted = __hip_atomic_load(&quiet_posted, __ATOMIC_SEQ_CST, __HIP_MEMORY_SCOPE_SYSTEM);
+    __hip_atomic_store(&quiet_posted, posted + num_wqes, __ATOMIC_SEQ_CST, __HIP_MEMORY_SCOPE_SYSTEM);
+    __hip_atomic_store(&sq_db_touched, wave_sq_counter + num_wqes, __ATOMIC_SEQ_CST, __HIP_MEMORY_SCOPE_SYSTEM);
   }
 }
 

--- a/src/gpu_ib/queue_pair.hpp
+++ b/src/gpu_ib/queue_pair.hpp
@@ -135,14 +135,14 @@ class QueuePair {
    *
    * @param[in] db_val Doorbell value is written by method.
    */
-  __device__ void ring_doorbell(uint64_t db_val, uint32_t my_sq_counter);
+  __device__ void ring_doorbell(uint64_t db_val, uint64_t my_sq_counter);
 
   db_reg_t db{};
 
-  uint32_t cq_consumer{0};
-  uint32_t quiet_posted{0};
-  uint32_t quiet_active{0};
-  uint32_t quiet_completed{0};
+  uint64_t cq_consumer{0};
+  uint64_t quiet_posted{0};
+  uint64_t quiet_active{0};
+  uint64_t quiet_completed{0};
 
   /*
    * struct mlx5dv_cq {
@@ -191,12 +191,12 @@ class QueuePair {
   uint64_t *sq_buf{nullptr};
   uint64_t *sq_buf_head{nullptr};
   uint16_t sq_wqe_cnt{0};
-  uint32_t sq_posted{0};
-  uint32_t sq_db_touched{0};
-  uint32_t sq_sunk{0};
+  uint64_t sq_posted{0};
+  uint64_t sq_db_touched{0};
+  uint64_t sq_sunk{0};
 
   static constexpr uint16_t OUTSTANDING_TABLE_SIZE = -1;
-  uint32_t outstanding_wqes[OUTSTANDING_TABLE_SIZE]{0};
+  uint64_t outstanding_wqes[OUTSTANDING_TABLE_SIZE]{0};
 
   uint32_t qp_num{0};
   uint32_t rkey{0};

--- a/src/gpu_ib/queue_pair.hpp
+++ b/src/gpu_ib/queue_pair.hpp
@@ -195,7 +195,7 @@ class QueuePair {
   uint64_t sq_db_touched{0};
   uint64_t sq_sunk{0};
 
-  static constexpr uint16_t OUTSTANDING_TABLE_SIZE = -1;
+  static constexpr size_t OUTSTANDING_TABLE_SIZE = 65536;
   uint64_t outstanding_wqes[OUTSTANDING_TABLE_SIZE]{0};
 
   uint32_t qp_num{0};


### PR DESCRIPTION
The gda_devel branch previously tried to use 32-bit counters to match some of the MLX types which use uint32_t.  This PR reverts this change and uses 64-bit counter values where appropriate (to allow greater than 2^32 number of requests).

Zero-initializes QueuePair allocations as a safety precaution.

The gda-devel branch previously tried to relax synchronization on queue counters with relaxed atomics.  This change broke both the blocking PUTs and non-blockings PUTs (basic functionality).  Somehow this was missed when running validation tests.  This PR reverts this change and uses conservative sequentially consistent atomics.  We may be able to relax these a bit, but will defer until later.

Placement new is used to initialize objects on device memory in some pieces of the code.  The QueuePair class is constructed multiple times in the code.  Instead of having the host construct this and write directly to device memory, the hipMemcpy routine is used instead.  (Avinash noticed that the previous method was causing errors with with the barrier_all test.)

MLX does not return a full 8B WQE ID in its CQEs.  Instead, it returns an abbreviated low-order 16-bits.  Currently, we use a table to temporarily hold the full 8B outstanding WQE requests using the uint16_t value as an index into the table.  These outstanding WQEs are used to update the SQ pointer to allow threads to understand that SQ has "freed" entries.  Unfortunately, the table size was off-by-one.  This fixes the bug to allocate a 65536 size table instead of (uint16_t)-1 for the size (which is size 65535).

