### PR TITLE
[GDA] Fix ibv_reg_mr when using sub-communicators

### DIFF
--- a/src/gpu_ib/backend_ib.cpp
+++ b/src/gpu_ib/backend_ib.cpp
@@ -64,7 +64,7 @@ int get_ls_non_zero_bit(char *bitmask, int mask_length) {
   return position;
 }
 
-GPUIBBackend::GPUIBBackend(MPI_Comm comm) {
+GPUIBBackend::GPUIBBackend(MPI_Comm comm) : heap{comm} {
   CHECK_HIP(hipMalloc(&print_lock, sizeof(*print_lock)));
   *print_lock = 0;
   int* print_lock_addr{nullptr};
@@ -79,16 +79,14 @@ GPUIBBackend::GPUIBBackend(MPI_Comm comm) {
     sstream >> maximum_num_contexts_;
   }
   init_mpi_once(comm);
-  NET_CHECK(MPI_Comm_dup(backend_comm, &gpu_ib_comm_world));
-  NET_CHECK(MPI_Comm_size(gpu_ib_comm_world, &num_pes));
-  NET_CHECK(MPI_Comm_rank(gpu_ib_comm_world, &my_pe));
-  host_interface = new HostInterface(gpu_ib_comm_world, &heap);
+  NET_CHECK(MPI_Comm_size(backend_comm, &num_pes));
+  NET_CHECK(MPI_Comm_rank(backend_comm, &my_pe));
+  host_interface = new HostInterface(backend_comm, &heap);
   setup_default_host_ctx();
   setup_team_world();
   rocshmem_collective_init();
   teams_init();
-  thread_comm = gpu_ib_comm_world;
-  NET_CHECK(MPI_Barrier(gpu_ib_comm_world));
+  NET_CHECK(MPI_Barrier(backend_comm));
   initialize_network();
   setup_ctxs();
 //  setup_default_ctx();
@@ -126,7 +124,7 @@ __device__ void GPUIBBackend::destroy_ctx(rocshmem_ctx_t *ctx) {
 }
 
 __host__ void GPUIBBackend::global_exit(int status) {
-  MPI_Abort(gpu_ib_comm_world, status);
+  MPI_Abort(backend_comm, status);
 }
 
 void GPUIBBackend::create_new_team([[maybe_unused]] Team *parent_team, TeamInfo *team_info_wrt_parent, TeamInfo *team_info_wrt_world, int num_pes,
@@ -190,7 +188,7 @@ void GPUIBBackend::setup_team_world() {
   new (team_info_wrt_parent) TeamInfo(nullptr, 0, 1, num_pes);
   new (team_info_wrt_world) TeamInfo(nullptr, 0, 1, num_pes);
   MPI_Comm team_world_comm;
-  NET_CHECK(MPI_Comm_dup(gpu_ib_comm_world, &team_world_comm));
+  NET_CHECK(MPI_Comm_dup(backend_comm, &team_world_comm));
   GPUIBTeam *team_world{nullptr};
   CHECK_HIP(hipMalloc(&team_world, sizeof(GPUIBTeam)));
   new (team_world) GPUIBTeam(this, team_info_wrt_parent, team_info_wrt_world, num_pes, my_pe, team_world_comm, 0);
@@ -242,7 +240,7 @@ void GPUIBBackend::teams_init() {
     int byte_i = bit_i / CHAR_BIT;
     pool_bitmask_[byte_i] |= 1 << (bit_i % CHAR_BIT);
   }
-  NET_CHECK(MPI_Barrier(gpu_ib_comm_world));
+  NET_CHECK(MPI_Barrier(backend_comm));
 }
 
 void GPUIBBackend::teams_destroy() {
@@ -258,7 +256,7 @@ void GPUIBBackend::rocshmem_collective_init() {
   for (int i{0}; i < num_pes; i++) {
     barrier_sync[i] = ROCSHMEM_SYNC_VALUE;
   }
-  NET_CHECK(MPI_Barrier(gpu_ib_comm_world));
+  NET_CHECK(MPI_Barrier(backend_comm));
 }
 
 void GPUIBBackend::track_ctx(Context* ctx) {
@@ -285,7 +283,7 @@ GPUIBBackend::~GPUIBBackend() {
   team_world->~Team();
   CHECK_HIP(hipFree(team_world));
   delete default_host_ctx_;
-  NET_CHECK(MPI_Comm_free(&gpu_ib_comm_world));
+  NET_CHECK(MPI_Comm_free(&backend_comm));
   if (default_ctx_) {
     CHECK_HIP(hipFree(default_ctx_->device_qp_proxy));
     CHECK_HIP(hipFree(default_ctx_));

--- a/src/gpu_ib/backend_ib.hpp
+++ b/src/gpu_ib/backend_ib.hpp
@@ -214,7 +214,6 @@ class GPUIBBackend {
    * @brief rocSHMEM's copy of MPI_COMM_WORLD (for interoperability
    * with orthogonal MPI usage in an MPI+rocSHMEM program).
    */
-  MPI_Comm gpu_ib_comm_world{};
   MPI_Comm backend_comm{};
 
   /**
@@ -280,8 +279,6 @@ class GPUIBBackend {
    * num_pes (exclusive) [0 ... num_pes).
    */
   int my_pe{-1};
-
-  MPI_Comm thread_comm{};
 
   /**
    * @brief Object contains the interface and internal data structures

--- a/src/gpu_ib/connection.cpp
+++ b/src/gpu_ib/connection.cpp
@@ -32,7 +32,7 @@
 namespace rocshmem {
 
 static void dump_ibv_context(struct ibv_context* x) {
-  /* 
+  /*
    * struct ibv_context {
    *   struct ibv_device      *device;
    *   struct ibv_context_ops  ops;
@@ -98,30 +98,30 @@ static void dump_ibv_pd(struct ibv_pd* x) {
 
 static void dump_ibv_port_attr(struct ibv_port_attr* x) {
   /*
-   * struct ibv_port_attr { 
-   *   enum ibv_port_state     state; 
-   *   enum ibv_mtu            max_mtu; 
-   *   enum ibv_mtu            active_mtu; 
-   *   int                     gid_tbl_len; 
-   *   uint32_t                port_cap_flags; 
-   *   uint32_t                max_msg_sz; 
-   *   uint32_t                bad_pkey_cntr; 
-   *   uint32_t                qkey_viol_cntr; 
-   *   uint16_t                pkey_tbl_len; 
-   *   uint16_t                lid; 
-   *   uint16_t                sm_lid; 
-   *   uint8_t                 lmc; 
-   *   uint8_t                 max_vl_num; 
-   *   uint8_t                 sm_sl; 
-   *   uint8_t                 subnet_timeout; 
-   *   uint8_t                 init_type_reply; 
-   *   uint8_t                 active_width; 
-   *   uint8_t                 active_speed; 
-   *   uint8_t                 phys_state; 
-   *   uint8_t                 link_layer; 
-   *   uint8_t                 flags; 
-   *   uint16_t                port_cap_flags2; 
-   * }; 
+   * struct ibv_port_attr {
+   *   enum ibv_port_state     state;
+   *   enum ibv_mtu            max_mtu;
+   *   enum ibv_mtu            active_mtu;
+   *   int                     gid_tbl_len;
+   *   uint32_t                port_cap_flags;
+   *   uint32_t                max_msg_sz;
+   *   uint32_t                bad_pkey_cntr;
+   *   uint32_t                qkey_viol_cntr;
+   *   uint16_t                pkey_tbl_len;
+   *   uint16_t                lid;
+   *   uint16_t                sm_lid;
+   *   uint8_t                 lmc;
+   *   uint8_t                 max_vl_num;
+   *   uint8_t                 sm_sl;
+   *   uint8_t                 subnet_timeout;
+   *   uint8_t                 init_type_reply;
+   *   uint8_t                 active_width;
+   *   uint8_t                 active_speed;
+   *   uint8_t                 phys_state;
+   *   uint8_t                 link_layer;
+   *   uint8_t                 flags;
+   *   uint16_t                port_cap_flags2;
+   * };
    */
   DPRINTF("\n"
          "===============================================\n"
@@ -254,6 +254,7 @@ Connection::~Connection() {
 
 void Connection::reg_mr(void* ptr, size_t size, ibv_mr** mr) {
   int access = IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE | IBV_ACCESS_REMOTE_READ | IBV_ACCESS_REMOTE_ATOMIC;
+
   *mr = ibv_reg_mr(ib_state->pd, ptr, size, access);
   GPUIB_CHECK_NNULL(*mr, "ibv_reg_mr");
 }
@@ -281,22 +282,22 @@ void Connection::initialize(int num_contexts) {
   uint8_t port{1};
   ib_init(ib_dev, port);
   create_qps(port, &ib_state->portinfo);
- 
+
   auto npes = backend->num_pes;
   auto dinfo = dest_info.data();
   for (int i{0}; i < num_contexts; i++) {
-    MPI_Alltoall(MPI_IN_PLACE, sizeof(dest_info_t), MPI_CHAR, dinfo + i * npes, sizeof(dest_info_t), MPI_CHAR, backend->thread_comm);
+    MPI_Alltoall(MPI_IN_PLACE, sizeof(dest_info_t), MPI_CHAR, dinfo + i * npes, sizeof(dest_info_t), MPI_CHAR, backend->backend_comm);
   }
 
   for (int i{0}; i < qps.size(); i++) {
     change_status_rtr(qps[i], &dest_info[i], port);
   }
-  MPI_Barrier(backend->thread_comm);
+  MPI_Barrier(backend->backend_comm);
   for (int i{0}; i < qps.size(); i++) {
     change_status_rts(qps[i], &dest_info[i]);
     dump_ibv_qp(qps[i], i);
   }
-  MPI_Barrier(backend->thread_comm);
+  MPI_Barrier(backend->backend_comm);
 }
 
 void Connection::finalize() {

--- a/src/gpu_ib/network_policy.cpp
+++ b/src/gpu_ib/network_policy.cpp
@@ -109,7 +109,7 @@ void NetworkImpl::networkHostSetup(GPUIBBackend *backend) {
   connection = new Connection(backend);
   connection->initialize(num_contexts);
   const auto &heap_bases{backend->heap.get_heap_bases()};
-  heap_memory_rkey(heap_bases[my_pe], backend->heap.get_size(), backend->thread_comm);
+  heap_memory_rkey(heap_bases[my_pe], backend->heap.get_size(), backend->backend_comm);
   setup_gpu_qps();
 }
 

--- a/src/memory/symmetric_heap.hpp
+++ b/src/memory/symmetric_heap.hpp
@@ -117,7 +117,7 @@ class SymmetricHeap {
   /**
    * @brief Implementation of remote heaps
    */
-  RemoteHeapInfoType remote_heap_info_{single_heap_.get_base_ptr(), single_heap_.get_size()};
+  RemoteHeapInfoType remote_heap_info_{};
 };
 
 }  // namespace rocshmem


### PR DESCRIPTION
- Fails at ibv_reg_mr when using subcommunicators
  - Issue can be replicated with the `rocshmem_init_attr_test` test
- This is a result incorrect merge conflict resolution when cherry-picking 
  - #79 
  - The code has been adjusted to now work