### PR TITLE
Serialize API access through QueuePair function by PE

### DIFF
--- a/src/gpu_ib/context_ib_device.cpp
+++ b/src/gpu_ib/context_ib_device.cpp
@@ -55,19 +55,35 @@ __device__ void *GPUIBContext::shmem_ptr(const void *dest, int pe) {
 
 __device__ void GPUIBContext::putmem(void *dest, const void *source, size_t nelems, int pe) {
   uint64_t L_offset = reinterpret_cast<char*>(dest) - base_heap[my_pe];
-  bool must_send_message = wf_coal_.coalesce(pe, source, dest, &nelems);
-  if (!must_send_message) return;
   auto *qp = getQueuePair(pe);
-  qp->put_nbi(base_heap[pe] + L_offset, source, nelems, pe);
-  qp->quiet();
+  bool need_turn {true};
+  uint64_t turns = __ballot(need_turn);
+  while (turns) {
+    uint8_t lane = __ffsll((unsigned long long)turns) - 1;
+    int pe_turn = __shfl(pe, lane);
+    if (pe_turn == pe) {
+      qp->put_nbi(base_heap[pe] + L_offset, source, nelems, pe);
+      qp->quiet();
+      need_turn = false;
+    }
+    turns = __ballot(need_turn);
+  }
 }
 
 __device__ void GPUIBContext::putmem_nbi(void *dest, const void *source, size_t nelems, int pe) {
   uint64_t L_offset = reinterpret_cast<char*>(dest) - base_heap[my_pe];
-  bool must_send_message = wf_coal_.coalesce(pe, source, dest, &nelems);
-  if (!must_send_message) return;
   auto *qp = getQueuePair(pe);
-  qp->put_nbi(base_heap[pe] + L_offset, source, nelems, pe);
+  bool need_turn {true};
+  uint64_t turns = __ballot(need_turn);
+  while (turns) {
+    uint8_t lane = __ffsll((unsigned long long)turns) - 1;
+    int pe_turn = __shfl(pe, lane);
+    if (pe_turn == pe) {
+      qp->put_nbi(base_heap[pe] + L_offset, source, nelems, pe);
+      need_turn = false;
+    }
+    turns = __ballot(need_turn);
+  }
 }
 
 __device__ void GPUIBContext::putmem_wave(void *dest, const void *source, size_t nelems, int pe) {

--- a/src/gpu_ib/context_ib_tmpl_device.hpp
+++ b/src/gpu_ib/context_ib_tmpl_device.hpp
@@ -49,36 +49,60 @@ template <typename T>
 __device__ T GPUIBContext::amo_fetch_add(void *dst, T value, int pe) {
   uint64_t L_offset = reinterpret_cast<char *>(dst) - base_heap[my_pe];
   auto *qp = getQueuePair(pe);
-  return qp->atomic_fetch(base_heap[pe] + L_offset, value, 0, pe, MLX5_OPCODE_ATOMIC_FA);
+  T ret_val = 0;
+  bool need_turn {true};
+  uint64_t turns = __ballot(need_turn);
+  while (turns) {
+    uint8_t lane = __ffsll((unsigned long long)turns) - 1;
+    int pe_turn = __shfl(pe, lane);
+    if (pe_turn == pe) {
+      ret_val =  qp->atomic_fetch(base_heap[pe] + L_offset, value, 0, pe, MLX5_OPCODE_ATOMIC_FA);
+      need_turn = false;
+    }
+    turns = __ballot(need_turn);
+  }
+  return ret_val;
 }
 
 template <typename T>
 __device__ T GPUIBContext::amo_fetch_cas(void *dst, T value, T cond, int pe) {
   uint64_t L_offset = reinterpret_cast<char *>(dst) - base_heap[my_pe];
   auto *qp = getQueuePair(pe);
-  return qp->atomic_fetch(base_heap[pe] + L_offset, value, cond, pe, MLX5_OPCODE_ATOMIC_CS);
+  T ret_val;
+  for (int i = 0; i < __AMDGCN_WAVEFRONT_SIZE; i++) {
+    ret_val = qp->atomic_fetch(base_heap[pe] + L_offset, value, cond, pe, MLX5_OPCODE_ATOMIC_CS);
+  }
+  return ret_val;
 }
 
 template <typename T>
 __device__ void GPUIBContext::amo_add(void *dst, T value, int pe) {
   uint64_t L_offset = reinterpret_cast<char *>(dst) - base_heap[my_pe];
   auto *qp = getQueuePair(pe);
-  qp->atomic_nofetch(base_heap[pe] + L_offset, value, 0, pe, MLX5_OPCODE_ATOMIC_FA);
+  bool need_turn {true};
+  uint64_t turns = __ballot(need_turn);
+  while (turns) {
+    uint8_t lane = __ffsll((unsigned long long)turns) - 1;
+    int pe_turn = __shfl(pe, lane);
+    if (pe_turn == pe) {
+      qp->atomic_nofetch(base_heap[pe] + L_offset, value, 0, pe, MLX5_OPCODE_ATOMIC_FA);
+      need_turn = false;
+    }
+    turns = __ballot(need_turn);
+  }
 }
 
 template <typename T>
 __device__ void GPUIBContext::amo_set(void *dst, T value, int pe) {
   uint64_t L_offset = reinterpret_cast<char *>(dst) - base_heap[my_pe];
-
   auto *qp = getQueuePair(pe);
-
   T ret_val;
   T cond = 0;
-  while ((ret_val = qp->atomic_fetch(base_heap[pe] + L_offset, value, cond, pe, MLX5_OPCODE_ATOMIC_CS))) {
-    if (ret_val == cond) {
-      break;
+  for (int i = 0; i < __AMDGCN_WAVEFRONT_SIZE; i++) {
+    while ((ret_val = qp->atomic_fetch(base_heap[pe] + L_offset, value, cond, pe, MLX5_OPCODE_ATOMIC_CS))) {
+      if (ret_val == cond) { break; }
+      cond = ret_val;
     }
-    cond = ret_val;
   }
 }
 
@@ -92,7 +116,9 @@ template <typename T>
 __device__ void GPUIBContext::amo_cas(void *dst, T value, T cond, int pe) {
   uint64_t L_offset = reinterpret_cast<char *>(dst) - base_heap[my_pe];
   auto *qp = getQueuePair(pe);
-  qp->atomic_nofetch(base_heap[pe] + L_offset, value, cond, pe, MLX5_OPCODE_ATOMIC_CS);
+  for (int i = 0; i < __AMDGCN_WAVEFRONT_SIZE; i++) {
+    qp->atomic_nofetch(base_heap[pe] + L_offset, value, cond, pe, MLX5_OPCODE_ATOMIC_CS);
+  }
 }
 
 template <typename T>


### PR DESCRIPTION
The queue pair interface needs to be executed without wavefront divergence and it's not tolerant of buildings WQEs for different QPs within the same wavefront (at the same time).

To avoid having to rewrite the code, we're going to serialize the wavefronts such the threads within the wavefront will take a turn per PE.