### PR TITLE
new tester: put to all pes from all lanes concurrently - ibgda

### DIFF
--- a/scripts/functional_tests/driver.sh
+++ b/scripts/functional_tests/driver.sh
@@ -108,7 +108,7 @@ ExecTest() {
   LAUNCHER=mpirun
   OPTIONS=" -n $NUM_RANKS -mca pml ucx"
   OPTIONS+=" -x ROCSHMEM_MAX_NUM_CONTEXTS=$ROCSHMEM_MAX_NUM_CONTEXTS"
-  OPTIONS+=" -x $PATH -x $LD_LIBRARY_PATH --display-map"
+  OPTIONS+=" -x PATH -x LD_LIBRARY_PATH --display map --map-by numa"
 
   if [[ "" != "$HOSTFILE" ]]
   then

--- a/src/util.hpp
+++ b/src/util.hpp
@@ -95,10 +95,10 @@ __device__ __forceinline__ int get_flat_block_size() {
 }
 
 /*
- * Returns the number of threads in the caller's flattened grid.
+ * Returns the number of blocks in the caller's flattened grid.
  */
 __device__ __forceinline__ int get_flat_grid_size() {
-  return get_flat_block_size() * hipGridDim_x * hipGridDim_y * hipGridDim_z;
+  return hipGridDim_x * hipGridDim_y * hipGridDim_z;
 }
 
 /*

--- a/tests/functional_tests/CMakeLists.txt
+++ b/tests/functional_tests/CMakeLists.txt
@@ -52,6 +52,7 @@ target_sources(
     shmem_ptr_tester.cpp
     empty_tester.cpp
     wavefront_primitives.cpp
+    put_a2a_tester.cpp
 )
 
 ###############################################################################

--- a/tests/functional_tests/put_a2a_tester.cpp
+++ b/tests/functional_tests/put_a2a_tester.cpp
@@ -36,8 +36,7 @@ __global__ void PutA2aTest(int loop, int skip, long long int *start_time,
                             ShmemContextType ctx_type) {
   __shared__ rocshmem_ctx_t ctx;
 
-  rocshmem_wg_init();
-  rocshmem_wg_ctx_create(ctx_type, &ctx);
+  rocshmem_wg_ctx_create(&ctx);
 
   int num_pe {rocshmem_ctx_n_pes(ctx)};
   int num_wg {get_flat_grid_size()};
@@ -72,7 +71,6 @@ __global__ void PutA2aTest(int loop, int skip, long long int *start_time,
     end_time[wg_id] = wall_clock64();
   }
   rocshmem_wg_ctx_destroy(&ctx);
-  rocshmem_wg_finalize();
 }
 
 /******************************************************************************

--- a/tests/functional_tests/put_a2a_tester.cpp
+++ b/tests/functional_tests/put_a2a_tester.cpp
@@ -1,0 +1,128 @@
+/******************************************************************************
+ * Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ *****************************************************************************/
+
+#include "put_a2a_tester.hpp"
+
+#include <rocshmem/rocshmem.hpp>
+
+using namespace rocshmem;
+
+/******************************************************************************
+ * DEVICE TEST KERNEL
+ *****************************************************************************/
+__global__ void PutA2aTest(int loop, int skip, long long int *start_time,
+                            long long int *end_time, int *r_buf, int *s_buf,
+                            ShmemContextType ctx_type) {
+  __shared__ rocshmem_ctx_t ctx;
+
+  rocshmem_wg_init();
+  rocshmem_wg_ctx_create(ctx_type, &ctx);
+
+  int num_pe {rocshmem_ctx_n_pes(ctx)};
+  int num_wg {get_flat_grid_size()};
+  int num_wl {get_flat_block_size()};
+  int my_pe {rocshmem_ctx_my_pe(ctx)};
+  int wg_id {get_flat_grid_id()};
+  int wl_id {get_flat_block_id()};
+
+  auto wl_offset {wg_id * num_wl + wl_id};
+  auto tgt_offset {my_pe * num_wg * num_wl + wl_offset};
+
+//  printf("%02d:%02d:%02d: num_pe=%d, num_wg=%d, num_wl=%d, wl_offset=%d, tgt_offset=%d\n", my_pe, wg_id, wl_id, num_pe, num_wg, num_wl, wl_offset, tgt_offset);
+
+  for (int i = 0; i < loop + skip; i++) {
+    if (i == skip) {
+      start_time[wg_id] = wall_clock64();
+    }
+
+    for (int j{0}; j < num_pe; j++) {
+      // shuffle ordering so that threads in the wave put to a
+      // different pe 'simultaneously'
+      auto pe = (wl_id + j) % num_pe;
+      rocshmem_ctx_putmem(ctx, &r_buf[tgt_offset], &s_buf[wl_offset], sizeof(int), pe);
+    }
+    __syncthreads();
+    if (is_thread_zero_in_wave()) {
+      rocshmem_ctx_quiet(ctx);
+    }
+  }
+  __syncthreads();
+  if (is_thread_zero_in_wave()) {
+    end_time[wg_id] = wall_clock64();
+  }
+  rocshmem_wg_ctx_destroy(&ctx);
+  rocshmem_wg_finalize();
+}
+
+/******************************************************************************
+ * HOST TESTER CLASS METHODS
+ *****************************************************************************/
+PutA2aTester::PutA2aTester(TesterArguments args) : Tester(args) {
+  int num_pes {rocshmem_n_pes()};
+  int my_pe {rocshmem_my_pe()};
+  s_buf = (int *)rocshmem_malloc(sizeof(int) * args.num_wgs * args.wg_size);
+  printf("%02d:xx:xx: num_wgs=%d, wg_size=%d\n", my_pe, args.num_wgs, args.wg_size);
+  for(int wg = 0; wg < args.num_wgs; wg++) for(int lane = 0; lane < args.wg_size; lane++) {
+    s_buf[wg * args.wg_size + lane] = (my_pe<<24) + (wg<<16) + lane; // set value for verification
+  }
+  r_buf = (int *)rocshmem_malloc(sizeof(int) * args.num_wgs * args.wg_size * num_pes);
+}
+
+PutA2aTester::~PutA2aTester() {
+  rocshmem_free(s_buf);
+  rocshmem_free(r_buf);
+}
+
+void PutA2aTester::resetBuffers(uint64_t size) {
+  int num_pes {rocshmem_n_pes()};
+  memset(r_buf, 0, sizeof(int) * args.num_wgs * args.wg_size * num_pes);
+}
+
+void PutA2aTester::launchKernel(dim3 gridSize, dim3 blockSize, int loop,
+                                uint64_t size) {
+  size_t shared_bytes = 0;
+
+  hipLaunchKernelGGL(PutA2aTest, gridSize, blockSize, shared_bytes, stream,
+                     loop, args.skip, start_time, end_time, r_buf, s_buf,
+                     _shmem_context);
+
+  num_msgs = (loop + args.skip) * gridSize.x * blockSize.x;
+  num_timed_msgs = loop * gridSize.x * blockSize.x;
+}
+
+void PutA2aTester::verifyResults(uint64_t size) {
+  int num_pes {rocshmem_n_pes()};
+  int my_pe {rocshmem_my_pe()};
+  if (num_pes > 256 || args.num_wgs > 256 || args.wg_size > 64*1024) {
+    // can't check
+  }
+#if 0
+  // TODO: write is as a kernel
+  for(int pe = 0; pe < num_pes; pe++)
+    for(int wg = 0; wg < args.num_wgs; wg++)
+      for(int lane = 0; lane < args.wg_size; lane++) {
+    if(
+  }
+#endif
+}

--- a/tests/functional_tests/put_a2a_tester.cpp
+++ b/tests/functional_tests/put_a2a_tester.cpp
@@ -102,13 +102,15 @@ void PutA2aTester::resetBuffers(uint64_t size) {
 void PutA2aTester::launchKernel(dim3 gridSize, dim3 blockSize, int loop,
                                 uint64_t size) {
   size_t shared_bytes = 0;
+  int num_pes {rocshmem_n_pes()};
 
   hipLaunchKernelGGL(PutA2aTest, gridSize, blockSize, shared_bytes, stream,
                      loop, args.skip, start_time, end_time, r_buf, s_buf,
                      _shmem_context);
 
-  num_msgs = (loop + args.skip) * gridSize.x * blockSize.x;
-  num_timed_msgs = loop * gridSize.x * blockSize.x;
+
+  num_msgs = (loop + args.skip) * gridSize.x * blockSize.x * num_pes;
+  num_timed_msgs = loop * gridSize.x * blockSize.x * num_pes;
 }
 
 void PutA2aTester::verifyResults(uint64_t size) {

--- a/tests/functional_tests/put_a2a_tester.hpp
+++ b/tests/functional_tests/put_a2a_tester.hpp
@@ -1,0 +1,56 @@
+/******************************************************************************
+ * Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ *****************************************************************************/
+
+#ifndef _PUT_A2A_TESTER_HPP_
+#define _PUT_A2A_TESTER_HPP_
+
+#include "tester.hpp"
+
+/******************************************************************************
+ * DEVICE TEST KERNEL
+ *****************************************************************************/
+__global__ void PutA2aTest(int loop, int skip, long long int *start_time,
+                            long long int *end_time, int *r_buf);
+
+/******************************************************************************
+ * HOST TESTER CLASS
+ *****************************************************************************/
+class PutA2aTester : public Tester {
+ public:
+  explicit PutA2aTester(TesterArguments args);
+  virtual ~PutA2aTester();
+
+ protected:
+  virtual void resetBuffers(uint64_t size) override;
+
+  virtual void launchKernel(dim3 gridSize, dim3 blockSize, int loop,
+                            uint64_t size) override;
+
+  virtual void verifyResults(uint64_t size) override;
+
+  int *r_buf;
+  int *s_buf;
+};
+
+#endif

--- a/tests/functional_tests/tester.cpp
+++ b/tests/functional_tests/tester.cpp
@@ -44,6 +44,7 @@
 #include "team_ctx_infra_tester.hpp"
 #include "team_ctx_primitive_tester.hpp"
 #include "wavefront_primitives.hpp"
+#include "put_a2a_tester.hpp"
 
 Tester::Tester(TesterArguments args) : args(args) {
   _type = (TestType)args.algorithm;
@@ -263,6 +264,10 @@ std::vector<Tester*> Tester::create(TesterArguments args) {
       if (rank == 0)
         std::cout << "Non-Blocking WAVE level Puts ###" << std::endl;
       testers.push_back(new WaveFrontPrimitiveTester(args));
+      return testers;
+    case PutA2aTestType:
+      if (rank == 0) std::cout << "A2A Put Multi Dest in Wave ###" << std::endl;
+      testers.push_back(new PutA2aTester(args));
       return testers;
     default:
       if (rank == 0) std::cout << "Empty Test ###" << std::endl;

--- a/tests/functional_tests/tester.hpp
+++ b/tests/functional_tests/tester.hpp
@@ -95,6 +95,7 @@ enum TestType {
   DefaultCTXGTestType = 64,
   WAVEBarrierAllTestType = 65,
   WGBarrierAllTestType = 66,
+  PutA2aTestType = 73,
 };
 
 enum OpType { PutType = 0, GetType = 1 };

--- a/tests/functional_tests/tester_arguments.cpp
+++ b/tests/functional_tests/tester_arguments.cpp
@@ -105,6 +105,9 @@ TesterArguments::TesterArguments(int argc, char *argv[]) {
     case PutNBIMRTestType:
       min_msg_size = max_msg_size;
       break;
+    case PutA2aTestType:
+      min_msg_size = max_msg_size = 4;
+      break;
     default:
       break;
   }
@@ -131,7 +134,7 @@ void TesterArguments::get_rocshmem_arguments() {
   if ((type != BarrierAllTestType) && (type != WAVEBarrierAllTestType) &&
       (type != WGBarrierAllTestType) && (type != SyncAllTestType) &&
       (type != SyncTestType) && (type != PingAllTestType) &&
-      (type != TeamBarrierTestType)) {
+      (type != TeamBarrierTestType) && (type != PutA2aTestType)) {
     if (numprocs != 2) {
       if (myid == 0) {
         std::cerr << "This test requires exactly two processes, we have "


### PR DESCRIPTION
variant of #112 for ib_gda branch 

typical use 
`mpirun  -n 64 -hostfile ~/hostfile-ppn8  -mca opal_abort_delay -1 -mca pml ucx -mca osc ucx -x ROCSHMEM_MAX_NUM_CONTEXTS=32 -x UCX_ROCM_IPC_SIGPOOL_MAX_ELEMS=16384 --display-comm --map-by numa --timeout 300 tests/functional_tests/rocshmem_example_driver -a 73 -w 8 -z 256`
