### PR TITLE
Fix broken rocSHMEM 6.4.0 APIs

### DIFF
--- a/src/ipc/context_ipc_device_coll.cpp
+++ b/src/ipc/context_ipc_device_coll.cpp
@@ -105,8 +105,9 @@ __device__ void IPCContext::sync(rocshmem_team_t team) {
   int pe_start = team_obj->tinfo_wrt_world->pe_start;
   int pe_stride = team_obj->tinfo_wrt_world->stride;
   int pe_size = team_obj->num_pes;
+  long *p_sync = team_obj->barrier_pSync;
 
-  internal_sync(pe, pe_start, pe_stride, pe_size, barrier_sync);
+  internal_sync(pe, pe_start, pe_stride, pe_size, p_sync);
 }
 
 __device__ void IPCContext::sync_all() {


### PR DESCRIPTION
Fixes the following APIs
- `rocshmem_ctx_my_pe`
  - returns team relative PE numbering
- `rocshmem_ctx_n_pes`
  - return team relative size
- `rocshmem_ctx_wg_team_sync`
  - uses the correct synchronization buffers