### PR TITLE
gpu_ib: Fix up putmem_wave()

### DIFF
--- a/src/gpu_ib/context_ib_device.cpp
+++ b/src/gpu_ib/context_ib_device.cpp
@@ -83,14 +83,16 @@ __device__ void GPUIBContext::putmem_nbi(void *dest, const void *source, size_t 
 
 __device__ void GPUIBContext::putmem_wave(void *dest, const void *source, size_t nelems, int pe) {
   uint64_t L_offset = reinterpret_cast<char*>(dest) - base_heap[my_pe];
-  qps[pe].put_nbi_wave(base_heap[pe] + L_offset, source, nelems, pe);
-  qps[pe].quiet();
+  if (is_thread_zero_in_wave()) {
+    qps[pe].put_nbi(base_heap[pe] + L_offset, source, nelems, pe);
+    qps[pe].quiet();
+  }
 }
 
 __device__ void GPUIBContext::putmem_nbi_wave(void *dest, const void *source, size_t nelems, int pe) {
   uint64_t L_offset = reinterpret_cast<char*>(dest) - base_heap[my_pe];
   if (is_thread_zero_in_wave()) {
-    qps[pe].put_nbi_wave(base_heap[pe] + L_offset, source, nelems, pe);
+    qps[pe].put_nbi(base_heap[pe] + L_offset, source, nelems, pe);
   }
 }
 

--- a/src/gpu_ib/queue_pair.cpp
+++ b/src/gpu_ib/queue_pair.cpp
@@ -286,12 +286,6 @@ __device__ void QueuePair::put_nbi(void *dest, const void *source, size_t nelems
   post_wqe_rma(pe, nelems, src, dst, MLX5_OPCODE_RDMA_WRITE);
 }
 
-__device__ void QueuePair::put_nbi_wave(void *dest, const void *source, size_t nelems, int pe) {
-  uintptr_t *src = reinterpret_cast<uintptr_t*>(const_cast<void*>(source));
-  uintptr_t *dst = reinterpret_cast<uintptr_t*>(dest);
-  post_wqe_rma(pe, nelems, src, dst, MLX5_OPCODE_RDMA_WRITE);
-}
-
 __device__ int64_t QueuePair::atomic_fetch(void *dest, int64_t atomic_data, int64_t atomic_cmp, int pe, uint8_t atomic_op) {
   uintptr_t *dst = reinterpret_cast<uintptr_t*>(dest);
   return post_wqe_amo(pe, sizeof(int64_t), dst, atomic_op, atomic_data, atomic_cmp, true);

--- a/src/gpu_ib/queue_pair.hpp
+++ b/src/gpu_ib/queue_pair.hpp
@@ -66,16 +66,6 @@ class QueuePair {
   __device__ void put_nbi(void *dest, const void *source, size_t nelems, int pe);
 
   /**
-   * @brief Create and enqueue a non-blocking put work queue entry (wqe).
-   *
-   * @param[in] dest Destination address for data transmission.
-   * @param[in] source Source address for data transmission.
-   * @param[in] nelems Size in bytes of data transmission.
-   * @param[in] pe Destination processing element of data transmission.
-   */
-  __device__ void put_nbi_wave(void *dest, const void *source, size_t nelems, int pe);
-
-  /**
    * @brief Empty all completions from the completion queue.
    */
   __device__ void quiet();


### PR DESCRIPTION
Add a thread ID check to GPUIBContext::putmem_wave() so that only one thread gets through.

Since the context layer checks, the QP layer doesn't need to. Thus QueuePair::put_nbi() and QueuePair::put_nbi_wave() are the same and can be combined.