### PR TITLE
[SWDEV-534546] Disable building tests in default build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,9 +56,9 @@ option(USE_SHARED_CTX "Request support for shared ctx between WG" OFF)
 option(USE_SINGLE_NODE "Enable single node support only." OFF)
 option(USE_HOST_SIDE_HDP_FLUSH "Use a polling thread to flush the HDP cache on the host." OFF)
 
-option(BUILD_FUNCTIONAL_TESTS "Build the functional tests" ON)
+option(BUILD_FUNCTIONAL_TESTS "Build the functional tests" OFF)
 option(BUILD_EXAMPLES "Build the examples" ON)
-option(BUILD_UNIT_TESTS "Build the unit tests" ON)
+option(BUILD_UNIT_TESTS "Build the unit tests" OFF)
 option(BUILD_TESTS_ONLY "Build only tests. Used to link agains rocSHMEM in a ROCm Release" OFF)
 
 option(BUILD_LOCAL_GPU_TARGET_ONLY "Build only for GPUs detected on this machine" OFF)

--- a/scripts/build_configs/ipc_single
+++ b/scripts/build_configs/ipc_single
@@ -51,6 +51,8 @@ cmake \
     -DUSE_SINGLE_NODE=ON \
     -DUSE_HOST_SIDE_HDP_FLUSH=OFF \
     -DBUILD_LOCAL_GPU_TARGET_ONLY=OFF \
+    -DBUILD_FUNCTIONAL_TESTS=ON \
+    -DBUILD_UNIT_TESTS=ON \
     $src_path
 cmake --build . --parallel 8
 cmake --install .

--- a/scripts/build_configs/ro_ipc
+++ b/scripts/build_configs/ro_ipc
@@ -50,6 +50,8 @@ cmake \
     -DUSE_HOST_SIDE_HDP_FLUSH=OFF\
     -DUSE_MANAGED_HEAP=OFF \
     -DUSE_RO=ON \
+    -DBUILD_FUNCTIONAL_TESTS=ON \
+    -DBUILD_UNIT_TESTS=ON \
     $src_path
 cmake --build . --parallel 8
 cmake --install .

--- a/scripts/build_configs/ro_net
+++ b/scripts/build_configs/ro_net
@@ -50,6 +50,8 @@ cmake \
     -DUSE_HOST_SIDE_HDP_FLUSH=OFF\
     -DUSE_MANAGED_HEAP=OFF \
     -DUSE_RO=ON \
+    -DBUILD_FUNCTIONAL_TESTS=ON \
+    -DBUILD_UNIT_TESTS=ON \
     $src_path
 cmake --build . --parallel 8
 cmake --install .

--- a/scripts/build_configs/ro_net_debug
+++ b/scripts/build_configs/ro_net_debug
@@ -48,6 +48,8 @@ cmake \
     -DUSE_HOST_SIDE_HDP_FLUSH=OFF\
     -DUSE_MANAGED_HEAP=OFF \
     -DUSE_RO=ON \
+    -DBUILD_FUNCTIONAL_TESTS=ON \
+    -DBUILD_UNIT_TESTS=ON \
     $src_path
 cmake --build . --parallel 8
 cmake --install .


### PR DESCRIPTION
# Problem

See SWDEV-534546

# Solution

- Disable building tests in default build.
- Enable building of tests in build_config scripts (keep things backwards compatible)