### PR TITLE
change default compilation mode for gda_devel

### DIFF
--- a/scripts/build_configs/rc
+++ b/scripts/build_configs/rc
@@ -12,7 +12,7 @@ fi
 src_path=$(dirname "$(realpath $0)")/../../
 
 cmake \
-    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_BUILD_TYPE=Debug \
     -DCMAKE_INSTALL_PREFIX=$install_path \
     -DCMAKE_VERBOSE_MAKEFILE=OFF \
     -DDEBUG=OFF \


### PR DESCRIPTION
for the moment, switch to Debug builds being the default, since it seems to be more stable with DeepEp