### PR TITLE
Refactor Barrier_all and Sync_all to use default context (GDA)

### DIFF
--- a/include/rocshmem/rocshmem.hpp
+++ b/include/rocshmem/rocshmem.hpp
@@ -391,13 +391,8 @@ __device__ int rocshmem_team_translate_pe(rocshmem_team_t src_team,
  *
  * This function must be invoked by a single thread within the PE.
  *
- * @param[in] handle GPU side handle.
- *
  * @return void
  */
-__device__ ATTR_NO_INLINE void rocshmem_ctx_barrier_all(
-    rocshmem_ctx_t ctx);
-
 __device__ ATTR_NO_INLINE void rocshmem_barrier_all();
 
 /**
@@ -406,13 +401,8 @@ __device__ ATTR_NO_INLINE void rocshmem_barrier_all();
  *
  * This function must be called as a wave-front collective.
  *
- * @param[in] handle GPU side handle.
- *
  * @return void
  */
-__device__ ATTR_NO_INLINE void rocshmem_ctx_barrier_all_wave(
-    rocshmem_ctx_t ctx);
-
 __device__ ATTR_NO_INLINE void rocshmem_barrier_all_wave();
 
 /**
@@ -421,13 +411,8 @@ __device__ ATTR_NO_INLINE void rocshmem_barrier_all_wave();
  *
  * This function must be called as a work-group collective.
  *
- * @param[in] handle GPU side handle.
- *
  * @return void
  */
-__device__ ATTR_NO_INLINE void rocshmem_ctx_barrier_all_wg(
-    rocshmem_ctx_t ctx);
-
 __device__ ATTR_NO_INLINE void rocshmem_barrier_all_wg();
 
 /**
@@ -483,11 +468,8 @@ __device__ void rocshmem_ctx_barrier_wg(rocshmem_ctx_t ctx, rocshmem_team_t team
  *
  * This function must be called as a work-group collective.
  *
- * @param[in] handle GPU side handle.
- *
  * @return void
  */
-__device__ ATTR_NO_INLINE void rocshmem_ctx_wg_sync_all(rocshmem_ctx_t ctx);
 
 __device__ ATTR_NO_INLINE void rocshmem_wg_sync_all();
 

--- a/src/gpu_ib/context_ib_device.cpp
+++ b/src/gpu_ib/context_ib_device.cpp
@@ -36,8 +36,7 @@ GPUIBContext::GPUIBContext(GDADevice *device, int idx)
   base_heap = device->heap.get_heap_bases().data();
   barrier_sync = device->barrier_sync;
   device->initialize_context(this, idx);
-  size_t barrier_sync_offset = idx * ROCSHMEM_BARRIER_SYNC_SIZE;
-  barrier_sync = device->barrier_sync + barrier_sync_offset;
+  barrier_sync = device->barrier_sync;
 }
 
 __device__ void GPUIBContext::quiet() {

--- a/src/gpu_ib/gda_device.cpp
+++ b/src/gpu_ib/gda_device.cpp
@@ -449,11 +449,10 @@ void GDADevice::destroy_team(rocshmem_team_t team) {
 
 void GDADevice::init_collective() {
   size_t one_sync_size_bytes {sizeof(*barrier_sync)};
-  size_t total_sync_elems {ROCSHMEM_BARRIER_SYNC_SIZE * (maximum_num_contexts_ + 1)};
-  size_t sync_size_bytes {one_sync_size_bytes * total_sync_elems};
+  size_t sync_size_bytes {one_sync_size_bytes * ROCSHMEM_BARRIER_SYNC_SIZE};
 
   heap.malloc(reinterpret_cast<void**>(&barrier_sync), sync_size_bytes);
-  for (int i{0}; i < total_sync_elems; i++) {
+  for (int i{0}; i < ROCSHMEM_BARRIER_SYNC_SIZE; i++) {
     barrier_sync[i] = ROCSHMEM_SYNC_VALUE;
   }
 

--- a/src/rocshmem_gpu.cpp
+++ b/src/rocshmem_gpu.cpp
@@ -217,33 +217,18 @@ void *rocshmem_ptr(const void *dest, int pe) {
 }
 
 __device__
-void rocshmem_ctx_barrier_all(rocshmem_ctx_t ctx) {
-  get_internal_ctx(ctx)->barrier_all();
-}
-
-__device__
-void rocshmem_ctx_barrier_all_wave(rocshmem_ctx_t ctx) {
-  get_internal_ctx(ctx)->barrier_all_wave();
-}
-
-__device__
-void rocshmem_ctx_barrier_all_wg(rocshmem_ctx_t ctx) {
-  get_internal_ctx(ctx)->barrier_all_wg();
-}
-
-__device__
 void rocshmem_barrier_all() {
-  rocshmem_ctx_barrier_all(ROCSHMEM_CTX_DEFAULT);
+  get_internal_ctx(ROCSHMEM_CTX_DEFAULT)->barrier_all();
 }
 
 __device__
 void rocshmem_barrier_all_wave() {
-  rocshmem_ctx_barrier_all_wave(ROCSHMEM_CTX_DEFAULT);
+  get_internal_ctx(ROCSHMEM_CTX_DEFAULT)->barrier_all();
 }
 
 __device__
 void rocshmem_barrier_all_wg() {
-  rocshmem_ctx_barrier_all_wg(ROCSHMEM_CTX_DEFAULT);
+  get_internal_ctx(ROCSHMEM_CTX_DEFAULT)->barrier_all();
 }
 
 __device__
@@ -260,13 +245,8 @@ __device__ void rocshmem_ctx_barrier_wg(rocshmem_ctx_t ctx, rocshmem_team_t team
 }
 
 __device__
-void rocshmem_ctx_wg_sync_all(rocshmem_ctx_t ctx) {
-  get_internal_ctx(ctx)->sync_all();
-}
-
-__device__
 void rocshmem_wg_sync_all() {
-  rocshmem_ctx_wg_sync_all(ROCSHMEM_CTX_DEFAULT);
+  get_internal_ctx(ROCSHMEM_CTX_DEFAULT)->sync_all();
 }
 
 __device__

--- a/tests/functional_tests/barrier_all_tester.cpp
+++ b/tests/functional_tests/barrier_all_tester.cpp
@@ -37,29 +37,41 @@ __global__ void BarrierAllTest(int loop, int skip, long long int *start_time,
   int wg_id = get_flat_grid_id();
   int wf_id = t_id / wf_size;
 
-  rocshmem_wg_ctx_create(&ctx);
-
   for (int i = 0; i < loop + skip; i++) {
     if (hipThreadIdx_x == 0 && i == skip) {
       start_time[wg_id] = wall_clock64();
     }
 
-    switch (type) {
-      case BarrierAllTestType:
-        if(t_id == 0) {
-          rocshmem_ctx_barrier_all(ctx);
-        }
-        break;
-      case WAVEBarrierAllTestType:
-        if(wf_id == 0) {
-          rocshmem_ctx_barrier_all_wave(ctx);
-        }
-        break;
-      case WGBarrierAllTestType:
-        rocshmem_ctx_barrier_all_wg(ctx);
-        break;
-      default:
-        break;
+    if (is_block_zero_in_grid()) {
+      switch (type) {
+        case BarrierAllTestType:
+          if(t_id == 0) {
+            /**
+              * The function `rocshmem_barrier_all` should be called from only
+              * one thread within the grid to avoid undefined behavior.
+              */
+            rocshmem_barrier_all();
+          }
+          break;
+        case WAVEBarrierAllTestType:
+          if(wf_id == 0) {
+            /**
+              * The function `rocshmem_barrier_all_wave` should be called from only
+              * one wavefront within the grid to avoid undefined behavior.
+              */
+            rocshmem_barrier_all_wave();
+          }
+          break;
+        case WGBarrierAllTestType:
+          /**
+            * The function `rocshmem_barrier_all_wg` should be called from only
+            * one workgroup within the grid to avoid undefined behavior.
+            */
+          rocshmem_barrier_all_wg();
+          break;
+        default:
+          break;
+      }
     }
     __syncthreads();
   }
@@ -67,8 +79,6 @@ __global__ void BarrierAllTest(int loop, int skip, long long int *start_time,
   if (hipThreadIdx_x == 0) {
     end_time[wg_id] = wall_clock64();
   }
-
-  rocshmem_wg_ctx_destroy(&ctx);
 }
 
 /******************************************************************************
@@ -85,8 +95,8 @@ void BarrierAllTester::launchKernel(dim3 gridSize, dim3 blockSize, int loop,
   hipLaunchKernelGGL(BarrierAllTest, gridSize, blockSize, shared_bytes, stream,
                      loop, args.skip, start_time, end_time, _type, wf_size);
 
-  num_msgs = (loop + args.skip) * gridSize.x;
-  num_timed_msgs = loop * gridSize.x;
+  num_msgs = (loop + args.skip);
+  num_timed_msgs = loop;
 }
 
 void BarrierAllTester::resetBuffers(uint64_t size) {}

--- a/tests/functional_tests/sync_tester.cpp
+++ b/tests/functional_tests/sync_tester.cpp
@@ -42,11 +42,11 @@ __global__ void SyncTest(int loop, int skip, long long int *start_time,
     switch (type) {
       case SyncAllTestType:
         /**
-        * The function `rocshmem_ctx_wg_sync_all` should be called from only
+        * The function `rocshmem_wg_sync_all` should be called from only
         * one group within the grid to avoid unintended behavior.
         */
         if (is_block_zero_in_grid()) {
-          rocshmem_ctx_wg_sync_all(ctx);
+          rocshmem_wg_sync_all();
         }
         break;
       case SyncTestType:


### PR DESCRIPTION
- Removed context-specific implementations of barrier_all and sync_all
- Added barrier_all and sync_all to the default context implementation
- Updated functional tests to use the default context for barrier_all and sync_all