### PR TITLE
Fix pSync buffer initialization

### DIFF
--- a/src/ipc/backend_ipc.cpp
+++ b/src/ipc/backend_ipc.cpp
@@ -454,7 +454,7 @@ void IPCBackend::rocshmem_collective_init() {
   /*
    * Initialize the barrier synchronization array with default values.
    */
-  for (int i = 0; i < num_pes; i++) {
+  for (int i = 0; i < ROCSHMEM_BARRIER_SYNC_SIZE; i++) {
     barrier_sync[i] = ROCSHMEM_SYNC_VALUE;
   }
 


### PR DESCRIPTION
- Initialize the entire pSync buffer with the default synchronization value