### PR TITLE
rocshmem_config.h has a different include path when installed and built-dir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,7 +151,7 @@ if (NOT BUILD_TESTS_ONLY)
   set(THREADS_PREFER_PTHREAD_FLAG TRUE)
   find_package(Threads REQUIRED)
 
-  configure_file(cmake/rocshmem_config.h.in rocshmem_config.h)
+  configure_file(cmake/rocshmem_config.h.in include/rocshmem/rocshmem_config.h)
 
   #############################################################################
   # LINKING AND INCLUDE DIRECTORIES
@@ -167,7 +167,7 @@ if (NOT BUILD_TESTS_ONLY)
     ${PROJECT_NAME}
     PUBLIC
       $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-      $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}>               # rocshmem_config.h
+      $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/include>       # rocshmem_config.h
       $<INSTALL_INTERFACE:include>
   )
 
@@ -196,7 +196,7 @@ if (NOT BUILD_TESTS_ONLY)
   )
 
   rocm_install(
-    FILES "${CMAKE_BINARY_DIR}/rocshmem_config.h"
+    FILES "${CMAKE_BINARY_DIR}/include/rocshmem/rocshmem_config.h"
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/rocshmem
   )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -167,7 +167,8 @@ if (NOT BUILD_TESTS_ONLY)
     ${PROJECT_NAME}
     PUBLIC
       $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-      $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/include>       # rocshmem_config.h
+      $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/include>            # rocshmem_config.h
+      $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/include/rocshmem>   # rocshmem_config.h from rocshmem.hpp
       $<INSTALL_INTERFACE:include>
   )
 

--- a/include/rocshmem/rocshmem.hpp
+++ b/include/rocshmem/rocshmem.hpp
@@ -28,7 +28,7 @@
 #include <hip/hip_runtime.h>
 #include <mpi.h>
 
-#include "rocshmem_config.h"
+#include "rocshmem/rocshmem_config.h"
 #include "rocshmem_common.hpp"
 #include "rocshmem_RMA.hpp"
 #include "rocshmem_AMO.hpp"

--- a/include/rocshmem/rocshmem.hpp
+++ b/include/rocshmem/rocshmem.hpp
@@ -28,7 +28,7 @@
 #include <hip/hip_runtime.h>
 #include <mpi.h>
 
-#include "rocshmem/rocshmem_config.h"
+#include "rocshmem_config.h"
 #include "rocshmem_common.hpp"
 #include "rocshmem_RMA.hpp"
 #include "rocshmem_AMO.hpp"

--- a/src/backend_bc.hpp
+++ b/src/backend_bc.hpp
@@ -37,7 +37,7 @@
 
 #include <vector>
 
-#include "rocshmem_config.h"  // NOLINT(build/include_subdir)
+#include "rocshmem/rocshmem_config.h"  // NOLINT(build/include_subdir)
 #include "rocshmem/rocshmem.hpp"
 #include "backend_type.hpp"
 #include "ipc_policy.hpp"

--- a/src/backend_type.hpp
+++ b/src/backend_type.hpp
@@ -36,7 +36,7 @@
  * functions are not supported at this time.
  */
 
-#include "rocshmem_config.h"  // NOLINT(build/include_subdir)
+#include "rocshmem/rocshmem_config.h"  // NOLINT(build/include_subdir)
 
 namespace rocshmem {
 

--- a/src/context_device.cpp
+++ b/src/context_device.cpp
@@ -22,7 +22,7 @@
  * IN THE SOFTWARE.
  *****************************************************************************/
 
-#include "rocshmem_config.h"  // NOLINT(build/include_subdir)
+#include "rocshmem/rocshmem_config.h"  // NOLINT(build/include_subdir)
 #include "backend_bc.hpp"
 #include "context_incl.hpp"
 #include "util.hpp"

--- a/src/context_host.cpp
+++ b/src/context_host.cpp
@@ -22,7 +22,7 @@
  * IN THE SOFTWARE.
  *****************************************************************************/
 
-#include "rocshmem_config.h"  // NOLINT(build/include_subdir)
+#include "rocshmem/rocshmem_config.h"  // NOLINT(build/include_subdir)
 #include "backend_bc.hpp"
 #include "context_incl.hpp"
 

--- a/src/context_tmpl_device.hpp
+++ b/src/context_tmpl_device.hpp
@@ -25,7 +25,7 @@
 #ifndef LIBRARY_SRC_CONTEXT_TMPL_DEVICE_HPP_
 #define LIBRARY_SRC_CONTEXT_TMPL_DEVICE_HPP_
 
-#include "rocshmem_config.h"  // NOLINT(build/include_subdir)
+#include "rocshmem/rocshmem_config.h"  // NOLINT(build/include_subdir)
 #include "backend_type.hpp"
 #ifdef USE_RO
 #include "reverse_offload/context_ro_device.hpp"

--- a/src/context_tmpl_host.hpp
+++ b/src/context_tmpl_host.hpp
@@ -25,7 +25,7 @@
 #ifndef LIBRARY_SRC_CONTEXT_TMPL_HOST_HPP_
 #define LIBRARY_SRC_CONTEXT_TMPL_HOST_HPP_
 
-#include "rocshmem_config.h"  // NOLINT(build/include_subdir)
+#include "rocshmem/rocshmem_config.h"  // NOLINT(build/include_subdir)
 #include "backend_type.hpp"
 #ifdef USE_RO
 #include "reverse_offload/context_ro_host.hpp"

--- a/src/hdp_policy.hpp
+++ b/src/hdp_policy.hpp
@@ -28,7 +28,7 @@
 #include <hip/hip_runtime.h>
 #include <hsa/hsa_ext_amd.h>
 
-#include "rocshmem_config.h"  // NOLINT(build/include_subdir)
+#include "rocshmem/rocshmem_config.h"  // NOLINT(build/include_subdir)
 #include "memory/hip_allocator.hpp"
 #include "util.hpp"
 

--- a/src/host/host.cpp
+++ b/src/host/host.cpp
@@ -26,7 +26,7 @@
 
 #include <mpi.h>
 
-#include "rocshmem_config.h"  // NOLINT(build/include_subdir)
+#include "rocshmem/rocshmem_config.h"  // NOLINT(build/include_subdir)
 #include "host_helpers.hpp"
 #include "../memory/window_info.hpp"
 #include "../util.hpp"

--- a/src/host/host_templates.hpp
+++ b/src/host/host_templates.hpp
@@ -25,7 +25,7 @@
 #ifndef LIBRARY_SRC_HOST_HOST_TEMPLATES_HPP_
 #define LIBRARY_SRC_HOST_HOST_TEMPLATES_HPP_
 
-#include "rocshmem_config.h"  // NOLINT(build/include_subdir)
+#include "rocshmem/rocshmem_config.h"  // NOLINT(build/include_subdir)
 #include "host_helpers.hpp"
 #include "../memory/window_info.hpp"
 #include "../team.hpp"

--- a/src/ipc/context_ipc_device.cpp
+++ b/src/ipc/context_ipc_device.cpp
@@ -32,7 +32,7 @@
 #include <cstdio>
 #include <cstdlib>
 
-#include "rocshmem_config.h"  // NOLINT(build/include_subdir)
+#include "rocshmem/rocshmem_config.h"  // NOLINT(build/include_subdir)
 #include "rocshmem/rocshmem.hpp"
 #include "backend_ipc.hpp"
 

--- a/src/ipc/context_ipc_host.cpp
+++ b/src/ipc/context_ipc_host.cpp
@@ -26,7 +26,7 @@
 
 #include <mpi.h>
 
-#include "rocshmem_config.h"  // NOLINT(build/include_subdir)
+#include "rocshmem/rocshmem_config.h"  // NOLINT(build/include_subdir)
 #include "../backend_type.hpp"
 #include "../context_incl.hpp"
 #include "backend_ipc.hpp"

--- a/src/ipc/context_ipc_tmpl_device.hpp
+++ b/src/ipc/context_ipc_tmpl_device.hpp
@@ -25,7 +25,7 @@
 #ifndef LIBRARY_SRC_IPC_CONTEXT_TMPL_DEVICE_HPP_
 #define LIBRARY_SRC_IPC_CONTEXT_TMPL_DEVICE_HPP_
 
-#include "rocshmem_config.h"  // NOLINT(build/include_subdir)
+#include "rocshmem/rocshmem_config.h"  // NOLINT(build/include_subdir)
 #include "rocshmem/rocshmem.hpp"
 #include "context_ipc_device.hpp"
 #include "../util.hpp"

--- a/src/ipc/context_ipc_tmpl_host.hpp
+++ b/src/ipc/context_ipc_tmpl_host.hpp
@@ -25,7 +25,7 @@
 #ifndef LIBRARY_SRC_IPC_CONTEXT_TMPL_HOST_HPP_
 #define LIBRARY_SRC_IPC_CONTEXT_TMPL_HOST_HPP_
 
-#include "rocshmem_config.h"  // NOLINT(build/include_subdir)
+#include "rocshmem/rocshmem_config.h"  // NOLINT(build/include_subdir)
 #include "../host/host_templates.hpp"
 
 namespace rocshmem {

--- a/src/ipc_policy.cpp
+++ b/src/ipc_policy.cpp
@@ -26,7 +26,7 @@
 
 #include <mpi.h>
 
-#include "rocshmem_config.h"  // NOLINT(build/include_subdir)
+#include "rocshmem/rocshmem_config.h"  // NOLINT(build/include_subdir)
 #include "backend_bc.hpp"
 #include "context_incl.hpp"
 #include "util.hpp"

--- a/src/ipc_policy.hpp
+++ b/src/ipc_policy.hpp
@@ -31,7 +31,7 @@
 #include <atomic>
 #include <vector>
 
-#include "rocshmem_config.h"  // NOLINT(build/include_subdir)
+#include "rocshmem/rocshmem_config.h"  // NOLINT(build/include_subdir)
 #include "memory/hip_allocator.hpp"
 #include "util.hpp"
 #include "bootstrap/bootstrap.hpp"

--- a/src/memory/heap_type.hpp
+++ b/src/memory/heap_type.hpp
@@ -25,7 +25,7 @@
 #ifndef LIBRARY_SRC_MEMORY_HEAP_TYPE_HPP_
 #define LIBRARY_SRC_MEMORY_HEAP_TYPE_HPP_
 
-#include "rocshmem_config.h"  // NOLINT(build/include_subdir)
+#include "rocshmem/rocshmem_config.h"  // NOLINT(build/include_subdir)
 #include "hip_allocator.hpp"
 
 /**

--- a/src/memory/hip_allocator.hpp
+++ b/src/memory/hip_allocator.hpp
@@ -31,7 +31,7 @@
  * @brief Contains HIP wrapper class for memory allocator
  */
 
-#include "rocshmem_config.h"  // NOLINT(build/include_subdir)
+#include "rocshmem/rocshmem_config.h"  // NOLINT(build/include_subdir)
 #include "memory_allocator.hpp"
 
 #include <hip/hip_runtime_api.h>

--- a/src/reverse_offload/context_ro_device.cpp
+++ b/src/reverse_offload/context_ro_device.cpp
@@ -32,7 +32,7 @@
 #include <cstdio>
 #include <cstdlib>
 
-#include "rocshmem_config.h"  // NOLINT(build/include_subdir)
+#include "rocshmem/rocshmem_config.h"  // NOLINT(build/include_subdir)
 #include "rocshmem/rocshmem.hpp"
 #include "../backend_type.hpp"
 #include "../hdp_policy.hpp"

--- a/src/reverse_offload/context_ro_host.cpp
+++ b/src/reverse_offload/context_ro_host.cpp
@@ -26,7 +26,7 @@
 
 #include <mpi.h>
 
-#include "rocshmem_config.h"  // NOLINT(build/include_subdir)
+#include "rocshmem/rocshmem_config.h"  // NOLINT(build/include_subdir)
 #include "../backend_type.hpp"
 #include "../context_incl.hpp"
 #include "../host/host.hpp"

--- a/src/reverse_offload/context_ro_tmpl_device.hpp
+++ b/src/reverse_offload/context_ro_tmpl_device.hpp
@@ -25,7 +25,7 @@
 #ifndef LIBRARY_SRC_REVERSE_OFFLOAD_RO_NET_GPU_TEMPLATES_HPP_
 #define LIBRARY_SRC_REVERSE_OFFLOAD_RO_NET_GPU_TEMPLATES_HPP_
 
-#include "rocshmem_config.h"  // NOLINT(build/include_subdir)
+#include "rocshmem/rocshmem_config.h"  // NOLINT(build/include_subdir)
 #include "commands_types.hpp"
 #include "context_ro_device.hpp"
 #include "queue_proxy.hpp"

--- a/src/reverse_offload/context_ro_tmpl_host.hpp
+++ b/src/reverse_offload/context_ro_tmpl_host.hpp
@@ -25,7 +25,7 @@
 #ifndef LIBRARY_SRC_REVERSE_OFFLOAD_RO_NET_HOST_TEMPLATES_HPP_
 #define LIBRARY_SRC_REVERSE_OFFLOAD_RO_NET_HOST_TEMPLATES_HPP_
 
-#include "rocshmem_config.h"  // NOLINT(build/include_subdir)
+#include "rocshmem/rocshmem_config.h"  // NOLINT(build/include_subdir)
 #include "../host/host_templates.hpp"
 
 namespace rocshmem {

--- a/src/reverse_offload/profiler.hpp
+++ b/src/reverse_offload/profiler.hpp
@@ -28,7 +28,7 @@
 #include <array>
 #include <cassert>
 
-#include "rocshmem_config.h"  // NOLINT(build/include_subdir)
+#include "rocshmem/rocshmem_config.h"  // NOLINT(build/include_subdir)
 #include "../device_proxy.hpp"
 #include "../memory/../memory/hip_allocator.hpp"
 #include "../stats.hpp"

--- a/src/rocshmem_gpu.cpp
+++ b/src/rocshmem_gpu.cpp
@@ -43,7 +43,7 @@
 
 #include <cstdlib>
 
-#include "rocshmem_config.h"  // NOLINT(build/include_subdir)
+#include "rocshmem/rocshmem_config.h"  // NOLINT(build/include_subdir)
 #include "rocshmem/rocshmem.hpp"
 #include "backend_bc.hpp"
 #include "context_incl.hpp"

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -28,7 +28,7 @@
 #include <cstdlib>
 #include <vector>
 
-#include "rocshmem_config.h"  // NOLINT(build/include_subdir)
+#include "rocshmem/rocshmem_config.h"  // NOLINT(build/include_subdir)
 
 namespace rocshmem {
 

--- a/src/util.hpp
+++ b/src/util.hpp
@@ -32,7 +32,7 @@
 #include <cstdio>
 
 #include "assembly.hpp"
-#include "rocshmem_config.h"  // NOLINT(build/include_subdir)
+#include "rocshmem/rocshmem_config.h"  // NOLINT(build/include_subdir)
 #include "constants.hpp"
 
 namespace rocshmem {

--- a/src/wf_coal_policy.hpp
+++ b/src/wf_coal_policy.hpp
@@ -27,7 +27,7 @@
 
 #include <hip/hip_runtime.h>
 
-#include "rocshmem_config.h"  // NOLINT(build/include_subdir)
+#include "rocshmem/rocshmem_config.h"  // NOLINT(build/include_subdir)
 #include "util.hpp"
 
 namespace rocshmem {


### PR DESCRIPTION
Having rocshmem_config.h with different include path in build and install cases causes functional tests and unit tests to fail building in BUILD_TEST_ONLY configs. 

