### PR TITLE
rocSHMEM device API changes for bitcode support

### DIFF
--- a/include/rocshmem/rocshmem_common.hpp
+++ b/include/rocshmem/rocshmem_common.hpp
@@ -115,7 +115,7 @@ typedef struct {
 /**
  * Shmem default context.
  */
-extern __constant__ rocshmem_ctx_t ROCSHMEM_CTX_DEFAULT;
+extern "C" __device__  rocshmem_ctx_t __attribute__((visibility("default"))) ROCSHMEM_CTX_DEFAULT;
 
 /**
  * Used internally to set default context.

--- a/src/rocshmem_gpu.cpp
+++ b/src/rocshmem_gpu.cpp
@@ -63,7 +63,7 @@
 
 namespace rocshmem {
 
-__device__ __constant__ rocshmem_ctx_t ROCSHMEM_CTX_DEFAULT{};
+__device__  rocshmem_ctx_t __attribute__((visibility("default"))) ROCSHMEM_CTX_DEFAULT{};
 
 __constant__ Backend *device_backend_proxy;
 


### PR DESCRIPTION
ROCSHMEM_CTX_DEFAULT's visibility needs to be explicitly set to expose that as external device global variable in device bitcode.