### PR TITLE
Select MTU based on network config

### DIFF
--- a/src/gpu_ib/bnxt/gda_device_bnxt.cpp
+++ b/src/gpu_ib/bnxt/gda_device_bnxt.cpp
@@ -86,7 +86,7 @@ void GDADevice::change_status_rtr(ibv_qp *qp, dest_info_t *dest, uint8_t port) {
                               | IBV_QP_MIN_RNR_TIMER;
 
   attr.qp_state               = IBV_QPS_RTR;
-  attr.path_mtu               = IBV_MTU_4096;
+  artr.path_mtu               = ib_state->portinfo.active_mtu;
   attr.rq_psn                 = dest->psn;
   attr.dest_qp_num            = dest->qpn;
 

--- a/src/gpu_ib/gda_device.cpp
+++ b/src/gpu_ib/gda_device.cpp
@@ -992,6 +992,7 @@ GDADevice::RtrState GDADevice::rtr(dest_info_t* dest, uint8_t port) {
   rtr.exp_qp_attr.dest_qp_num = dest->qpn;
   rtr.exp_qp_attr.rq_psn = dest->psn;
   rtr.exp_qp_attr.ah_attr.port_num = port;
+  rtr.exp_qp_attr.path_mtu = ib_state->portinfo.active_mtu;
   if (ib_state->portinfo.link_layer == IBV_LINK_LAYER_INFINIBAND) {
     rtr.exp_qp_attr.ah_attr.dlid = dest->lid;
   } else {

--- a/src/gpu_ib/gda_device.hpp
+++ b/src/gpu_ib/gda_device.hpp
@@ -105,7 +105,6 @@ class GDADevice {
    public:
     RtrState() {
       exp_qp_attr.qp_state = IBV_QPS_RTR;
-      exp_qp_attr.path_mtu = IBV_MTU_4096;
       exp_qp_attr.ah_attr.sl = 1;
       exp_qp_attr.max_dest_rd_atomic = GPUIB_MAX_ATOMIC;
       exp_qp_attr.min_rnr_timer = 12;


### PR DESCRIPTION
## Motivation

Not all NICs have the same MTU configuration. Therefore, on some machines having a hardcoded MTU of 4096 causes issues.

## Technical Details
When we query the port info, we obtain the active MTU. We are now setting that as the MTU that the QP will be configured to use.





