### PR TITLE
Device bitcode support for IPC - Use IPCContext explicitly to link correct device API implementation

### DIFF
--- a/src/rocshmem_gpu.cpp
+++ b/src/rocshmem_gpu.cpp
@@ -314,7 +314,7 @@ __device__ int rocshmem_wg_ctx_create(long options, rocshmem_ctx_t *ctx) {
     ctx->team_opaque = reinterpret_cast<TeamInfo *>(ROCSHMEM_CTX_DEFAULT.team_opaque);
     result = device_backend_proxy->create_ctx(options, ctx);
     if(result) {
-      reinterpret_cast<ContextTy *>(ctx->ctx_opaque)->setFence(options);
+      reinterpret_cast<Context *>(ctx->ctx_opaque)->setFence(options);
     }
   }
   __syncthreads();
@@ -336,7 +336,7 @@ __device__ int rocshmem_wg_team_create_ctx(rocshmem_team_t team, long options,
     ctx->team_opaque = info_wrt_world;
     result = device_backend_proxy->create_ctx(options, ctx);
     if(result) {
-      reinterpret_cast<ContextTy *>(ctx->ctx_opaque)->setFence(options);
+      reinterpret_cast<Context *>(ctx->ctx_opaque)->setFence(options);
     }
   }
   __syncthreads();
@@ -533,7 +533,7 @@ __device__ void rocshmem_wait_until(T *ivars, int cmp, T val) {
   GPU_DPRINTF("Function: rocshmem_wait_until (ivars=%p, cmp=%d, val=%g)\n",
     ivars, cmp, (double)val);
 
-  ContextTy *ctx_internal = get_internal_ctx(ROCSHMEM_CTX_DEFAULT);
+  Context *ctx_internal = get_internal_ctx(ROCSHMEM_CTX_DEFAULT);
   ctx_internal->ctxStats.incStat(NUM_WAIT_UNTIL);
   ctx_internal->wait_until(ivars, cmp, val);
 }
@@ -544,7 +544,7 @@ __device__ void rocshmem_wait_until_all(T *ivars, size_t nelems, const int* stat
   GPU_DPRINTF("Function: rocshmem_wait_until_all (ivars=%p, nelems=%zd cmp=%d, val=%g)\n",
     ivars, nelems, cmp, (double)val);
 
-  ContextTy *ctx_internal = get_internal_ctx(ROCSHMEM_CTX_DEFAULT);
+  Context *ctx_internal = get_internal_ctx(ROCSHMEM_CTX_DEFAULT);
   ctx_internal->ctxStats.incStat(NUM_WAIT_UNTIL_ALL);
   ctx_internal->wait_until_all(ivars, nelems, status, cmp, val);
 }
@@ -555,7 +555,7 @@ __device__ size_t rocshmem_wait_until_any(T *ivars, size_t nelems, const int* st
   GPU_DPRINTF("Function: rocshmem_wait_until_any (ivars=%p, nelems=%zd cmp=%d, val=%g)\n",
     ivars, nelems, cmp, (double)val);
 
-  ContextTy *ctx_internal = get_internal_ctx(ROCSHMEM_CTX_DEFAULT);
+  Context *ctx_internal = get_internal_ctx(ROCSHMEM_CTX_DEFAULT);
   ctx_internal->ctxStats.incStat(NUM_WAIT_UNTIL_ANY);
   return ctx_internal->wait_until_any(ivars, nelems, status, cmp, val);
 }
@@ -567,7 +567,7 @@ __device__ size_t rocshmem_wait_until_some(T *ivars, size_t nelems, size_t* indi
   DPRINTF("Function: rocshmem_wait_until_some (ivars=%p, nelems=%zd cmp=%d, val=%g)\n",
     ivars, nelems, cmp, (double)val);
 
-  ContextTy *ctx_internal = get_internal_ctx(ROCSHMEM_CTX_DEFAULT);
+  Context *ctx_internal = get_internal_ctx(ROCSHMEM_CTX_DEFAULT);
   ctx_internal->ctxStats.incStat(NUM_WAIT_UNTIL_SOME);
   return ctx_internal->wait_until_some(ivars, nelems, indices, status, cmp, val);
 }
@@ -578,7 +578,7 @@ __device__ size_t rocshmem_wait_until_any_vector(T *ivars, size_t nelems, const 
   DPRINTF("Function: rocshmem_wait_until_any_vector (ivars=%p, nelems=%zd cmp=%d, vals=%p)\n",
     ivars, nelems, cmp, vals);
 
-  ContextTy *ctx_internal = get_internal_ctx(ROCSHMEM_CTX_DEFAULT);
+  Context *ctx_internal = get_internal_ctx(ROCSHMEM_CTX_DEFAULT);
   ctx_internal->ctxStats.incStat(NUM_WAIT_UNTIL_ANY_VECTOR);
   return ctx_internal->wait_until_any_vector(ivars, nelems, status, cmp, vals);
 }
@@ -589,7 +589,7 @@ __device__ void rocshmem_wait_until_all_vector(T *ivars, size_t nelems, const in
   DPRINTF("Function: rocshmem_wait_until_all_vector (ivars=%p, nelems=%zd cmp=%d, vals=%p)\n",
     ivars, nelems, cmp, vals);
 
-  ContextTy *ctx_internal = get_internal_ctx(ROCSHMEM_CTX_DEFAULT);
+  Context *ctx_internal = get_internal_ctx(ROCSHMEM_CTX_DEFAULT);
   ctx_internal->ctxStats.incStat(NUM_WAIT_UNTIL_ALL_VECTOR);
   ctx_internal->wait_until_all_vector(ivars, nelems, status, cmp, vals);
 }
@@ -602,7 +602,7 @@ __device__ size_t rocshmem_wait_until_some_vector(T *ivars, size_t nelems,
   DPRINTF("Function: rocshmem_wait_until_some_vector (ivars=%p, nelems=%zd cmp=%d, vals=%p)\n",
     ivars, nelems, cmp, vals);
 
-  ContextTy *ctx_internal = get_internal_ctx(ROCSHMEM_CTX_DEFAULT);
+  Context *ctx_internal = get_internal_ctx(ROCSHMEM_CTX_DEFAULT);
   ctx_internal->ctxStats.incStat(NUM_WAIT_UNTIL_SOME_VECTOR);
   return ctx_internal->wait_until_some_vector(ivars, nelems, indices, status, cmp, vals);
 }
@@ -612,7 +612,7 @@ __device__ int rocshmem_test(T *ivars, int cmp, T val) {
   GPU_DPRINTF("Function: rocshmem_test (ivars=%p, cmp=%d, val=%g)\n",
     ivars, cmp, (double)val);
 
-  ContextTy *ctx_internal = get_internal_ctx(ROCSHMEM_CTX_DEFAULT);
+  Context *ctx_internal = get_internal_ctx(ROCSHMEM_CTX_DEFAULT);
   ctx_internal->ctxStats.incStat(NUM_TEST);
 
   return ctx_internal->test(ivars, cmp, val);

--- a/src/rocshmem_gpu.cpp
+++ b/src/rocshmem_gpu.cpp
@@ -54,6 +54,9 @@
 #ifdef USE_RO
 #include "reverse_offload/context_ro_tmpl_device.hpp"
 #else
+#ifdef ENABLE_IPC_BITCODE
+  #include "ipc/backend_ipc.hpp"
+#endif
 #include "ipc/context_ipc_tmpl_device.hpp"
 #endif
 
@@ -66,6 +69,12 @@ namespace rocshmem {
 __device__  rocshmem_ctx_t __attribute__((visibility("default"))) ROCSHMEM_CTX_DEFAULT{};
 
 __constant__ Backend *device_backend_proxy;
+
+#ifdef ENABLE_IPC_BITCODE
+  typedef IPCContext ContextTy;
+#else
+  typedef Context ContextTy;
+#endif
 
 __device__ void rocshmem_wg_init() {
   int provided;
@@ -294,8 +303,8 @@ __host__ void set_internal_ctx(rocshmem_ctx_t *ctx) {
                               hipMemcpyHostToDevice));
 }
 
-__device__ Context *get_internal_ctx(rocshmem_ctx_t ctx) {
-  return reinterpret_cast<Context *>(ctx.ctx_opaque);
+__device__ ContextTy *get_internal_ctx(rocshmem_ctx_t ctx) {
+  return reinterpret_cast<ContextTy *>(ctx.ctx_opaque);
 }
 
 __device__ int rocshmem_wg_ctx_create(long options, rocshmem_ctx_t *ctx) {
@@ -305,7 +314,7 @@ __device__ int rocshmem_wg_ctx_create(long options, rocshmem_ctx_t *ctx) {
     ctx->team_opaque = reinterpret_cast<TeamInfo *>(ROCSHMEM_CTX_DEFAULT.team_opaque);
     result = device_backend_proxy->create_ctx(options, ctx);
     if(result) {
-      reinterpret_cast<Context *>(ctx->ctx_opaque)->setFence(options);
+      reinterpret_cast<ContextTy *>(ctx->ctx_opaque)->setFence(options);
     }
   }
   __syncthreads();
@@ -327,7 +336,7 @@ __device__ int rocshmem_wg_team_create_ctx(rocshmem_team_t team, long options,
     ctx->team_opaque = info_wrt_world;
     result = device_backend_proxy->create_ctx(options, ctx);
     if(result) {
-      reinterpret_cast<Context *>(ctx->ctx_opaque)->setFence(options);
+      reinterpret_cast<ContextTy *>(ctx->ctx_opaque)->setFence(options);
     }
   }
   __syncthreads();
@@ -524,7 +533,7 @@ __device__ void rocshmem_wait_until(T *ivars, int cmp, T val) {
   GPU_DPRINTF("Function: rocshmem_wait_until (ivars=%p, cmp=%d, val=%g)\n",
     ivars, cmp, (double)val);
 
-  Context *ctx_internal = get_internal_ctx(ROCSHMEM_CTX_DEFAULT);
+  ContextTy *ctx_internal = get_internal_ctx(ROCSHMEM_CTX_DEFAULT);
   ctx_internal->ctxStats.incStat(NUM_WAIT_UNTIL);
   ctx_internal->wait_until(ivars, cmp, val);
 }
@@ -535,7 +544,7 @@ __device__ void rocshmem_wait_until_all(T *ivars, size_t nelems, const int* stat
   GPU_DPRINTF("Function: rocshmem_wait_until_all (ivars=%p, nelems=%zd cmp=%d, val=%g)\n",
     ivars, nelems, cmp, (double)val);
 
-  Context *ctx_internal = get_internal_ctx(ROCSHMEM_CTX_DEFAULT);
+  ContextTy *ctx_internal = get_internal_ctx(ROCSHMEM_CTX_DEFAULT);
   ctx_internal->ctxStats.incStat(NUM_WAIT_UNTIL_ALL);
   ctx_internal->wait_until_all(ivars, nelems, status, cmp, val);
 }
@@ -546,7 +555,7 @@ __device__ size_t rocshmem_wait_until_any(T *ivars, size_t nelems, const int* st
   GPU_DPRINTF("Function: rocshmem_wait_until_any (ivars=%p, nelems=%zd cmp=%d, val=%g)\n",
     ivars, nelems, cmp, (double)val);
 
-  Context *ctx_internal = get_internal_ctx(ROCSHMEM_CTX_DEFAULT);
+  ContextTy *ctx_internal = get_internal_ctx(ROCSHMEM_CTX_DEFAULT);
   ctx_internal->ctxStats.incStat(NUM_WAIT_UNTIL_ANY);
   return ctx_internal->wait_until_any(ivars, nelems, status, cmp, val);
 }
@@ -558,7 +567,7 @@ __device__ size_t rocshmem_wait_until_some(T *ivars, size_t nelems, size_t* indi
   DPRINTF("Function: rocshmem_wait_until_some (ivars=%p, nelems=%zd cmp=%d, val=%g)\n",
     ivars, nelems, cmp, (double)val);
 
-  Context *ctx_internal = get_internal_ctx(ROCSHMEM_CTX_DEFAULT);
+  ContextTy *ctx_internal = get_internal_ctx(ROCSHMEM_CTX_DEFAULT);
   ctx_internal->ctxStats.incStat(NUM_WAIT_UNTIL_SOME);
   return ctx_internal->wait_until_some(ivars, nelems, indices, status, cmp, val);
 }
@@ -569,7 +578,7 @@ __device__ size_t rocshmem_wait_until_any_vector(T *ivars, size_t nelems, const 
   DPRINTF("Function: rocshmem_wait_until_any_vector (ivars=%p, nelems=%zd cmp=%d, vals=%p)\n",
     ivars, nelems, cmp, vals);
 
-  Context *ctx_internal = get_internal_ctx(ROCSHMEM_CTX_DEFAULT);
+  ContextTy *ctx_internal = get_internal_ctx(ROCSHMEM_CTX_DEFAULT);
   ctx_internal->ctxStats.incStat(NUM_WAIT_UNTIL_ANY_VECTOR);
   return ctx_internal->wait_until_any_vector(ivars, nelems, status, cmp, vals);
 }
@@ -580,7 +589,7 @@ __device__ void rocshmem_wait_until_all_vector(T *ivars, size_t nelems, const in
   DPRINTF("Function: rocshmem_wait_until_all_vector (ivars=%p, nelems=%zd cmp=%d, vals=%p)\n",
     ivars, nelems, cmp, vals);
 
-  Context *ctx_internal = get_internal_ctx(ROCSHMEM_CTX_DEFAULT);
+  ContextTy *ctx_internal = get_internal_ctx(ROCSHMEM_CTX_DEFAULT);
   ctx_internal->ctxStats.incStat(NUM_WAIT_UNTIL_ALL_VECTOR);
   ctx_internal->wait_until_all_vector(ivars, nelems, status, cmp, vals);
 }
@@ -593,7 +602,7 @@ __device__ size_t rocshmem_wait_until_some_vector(T *ivars, size_t nelems,
   DPRINTF("Function: rocshmem_wait_until_some_vector (ivars=%p, nelems=%zd cmp=%d, vals=%p)\n",
     ivars, nelems, cmp, vals);
 
-  Context *ctx_internal = get_internal_ctx(ROCSHMEM_CTX_DEFAULT);
+  ContextTy *ctx_internal = get_internal_ctx(ROCSHMEM_CTX_DEFAULT);
   ctx_internal->ctxStats.incStat(NUM_WAIT_UNTIL_SOME_VECTOR);
   return ctx_internal->wait_until_some_vector(ivars, nelems, indices, status, cmp, vals);
 }
@@ -603,7 +612,7 @@ __device__ int rocshmem_test(T *ivars, int cmp, T val) {
   GPU_DPRINTF("Function: rocshmem_test (ivars=%p, cmp=%d, val=%g)\n",
     ivars, cmp, (double)val);
 
-  Context *ctx_internal = get_internal_ctx(ROCSHMEM_CTX_DEFAULT);
+  ContextTy *ctx_internal = get_internal_ctx(ROCSHMEM_CTX_DEFAULT);
   ctx_internal->ctxStats.incStat(NUM_TEST);
 
   return ctx_internal->test(ivars, cmp, val);


### PR DESCRIPTION
## Motivation

During JIT compilation (in case of triton-dist) Device bitcode module is dynamically loaded after host initialization for specific backend is done (IPC for now) . Device bitcode is also built for specific backend and at runtime bitcode cannot infer inherited objects like Context (which is initialized at host init/setup time) so bitcode uses compile time macro like "ENABLE_IPC_BITCODE" to explicitly use specific backend context like IPCContext so that correct IPC backend implementation is linked from bitcode device API. 

## Technical Details

This change is effective for Device bitcode builds and each backend needs to build bitcode with macro like ENABLE_IPC_BITCODE. ENABLE_RO_BITCODE, ENABLE_IB_BITCODE to resolve and link device APIs correctly.

There will be follow-up changes to add scripts to build this Device bitcode library.

## Test Plan

This change has been tested as part of this PR - https://github.com/ByteDance-Seed/Triton-distributed/pull/86/

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
