### PR TITLE
mark rocshmem_set_attr_uniqueid_args param 'uid' as 'const rocshmem_uniqueid_t *

### DIFF
--- a/include/rocshmem/rocshmem.hpp
+++ b/include/rocshmem/rocshmem.hpp
@@ -140,7 +140,7 @@ __host__ int rocshmem_get_uniqueid(rocshmem_uniqueid_t *uid);
  *                     value
  */
 __host__ int rocshmem_set_attr_uniqueid_args(int rank, int nranks,
-                                             rocshmem_uniqueid_t *uid,
+                                             const rocshmem_uniqueid_t *uid,
                                              rocshmem_init_attr_t *attr);
 /**
  * @brief Query the thread mode used by the runtime.

--- a/src/rocshmem.cpp
+++ b/src/rocshmem.cpp
@@ -217,7 +217,7 @@ rocshmem_ctx_t ROCSHMEM_HOST_CTX_DEFAULT;
 }
 
 [[maybe_unused]] __host__ int rocshmem_set_attr_uniqueid_args(int rank, int nranks,
-							       rocshmem_uniqueid_t *uid,
+							       const rocshmem_uniqueid_t *uid,
 							       rocshmem_init_attr_t *attr) {
   if (uid == nullptr || attr == nullptr) {
       fprintf(stderr, "ROCSHMEM_ERROR: %s in file '%s' in line %d\n",


### PR DESCRIPTION


## Motivation

mark input only parameter as const, which is more reasonable. also better for tool that parses the header files and auto-generate some pybinding code.

## Technical Details

too simple to explain more

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
