### PR TITLE
gda_devel: teams with MPI initalization

### DIFF
--- a/scripts/functional_tests/driver.sh
+++ b/scripts/functional_tests/driver.sh
@@ -359,9 +359,8 @@ TestGDA() {
   ExecTest  "waveput"          2       2            128       1048576
   ExecTest  "waveput"          2       16           128       8
 
-#This should work
-#  ExecTest  "teamctxput"       2       4            128       1024
-#  ExecTest  "teamctxput"       2       16           256       1024
+  ExecTest  "teamctxput"       2       4            128       1024
+  ExecTest  "teamctxput"       2       16           256       1024
 
 #  ExecTest  "get"              2       1            1         1048576
 #  ExecTest  "get"              2       1            1024      512
@@ -379,7 +378,6 @@ TestGDA() {
 #  ExecTest  "waveget"          2       2            128       1048576
 #  ExecTest  "waveget"          2       16           128       8
 
-#This should work
 #  ExecTest  "teamctxget"       2       4            128       1024
 #  ExecTest  "teamctxget"       2       16           256       1024
 
@@ -388,7 +386,7 @@ TestGDA() {
 #  ExecTest  "g"                2       8            1         32
 #  ExecTest  "g"                2       16           128       4
 
-#Implemented but know incorrect
+#Implemented but known incorrect
 #  ExecTest  "p"                2       1            1         128
 #  ExecTest  "p"                2       1            1024      2
 #  ExecTest  "p"                2       8            1         32
@@ -412,9 +410,8 @@ TestGDA() {
   ExecTest  "waveputnbi"       2       2            128       1048576
   ExecTest  "waveputnbi"       2       16           128       8
 
-#This should work
-#  ExecTest  "teamctxputnbi"    2       4            128       1024
-#  ExecTest  "teamctxputnbi"    2       16           256       1024
+  ExecTest  "teamctxputnbi"    2       4            128       1024
+  ExecTest  "teamctxputnbi"    2       16           256       1024
 
 #  ExecTest  "getnbi"           2       1            1         1048576
 #  ExecTest  "getnbi"           2       1            1024      512
@@ -458,7 +455,7 @@ TestGDA() {
 #  ExecTest  "amo_finc"         2       8            1
 #  ExecTest  "amo_finc"         2       32           128
 
-#This works but tester required get
+#This works but tester requires get
 #  ExecTest  "amo_inc"          2       1            1
 #  ExecTest  "amo_inc"          2       1            1024
 #  ExecTest  "amo_inc"          2       8            1
@@ -470,7 +467,7 @@ TestGDA() {
 #  ExecTest  "amo_fadd"         2       8            1
 #  ExecTest  "amo_fadd"         2       32           128
 
-#This works but tester required get
+#This works but tester requires get
 #  ExecTest  "amo_add"          2       1            1
 #  ExecTest  "amo_add"          2       1            1024
 #  ExecTest  "amo_add"          2       8            1
@@ -487,14 +484,10 @@ TestGDA() {
   #       | Name             | Ranks | Workgroups | Threads | Max Message Size #
   ##############################################################################
   ExecTest  "barrierall"       2       1            1
-#This should work
-#  ExecTest  "teambarrier"      2       1            1
+  ExecTest  "teambarrier"      2       1            1
 
-#This should work
-#  ExecTest  "sync"             2       1            1
-
-#This should work
-#  ExecTest  "syncall"          2       1            1
+  ExecTest  "sync"             2       1            1
+  ExecTest  "syncall"          2       1            1
 
 #  ExecTest  "alltoall"         2       1            1         512
 
@@ -514,6 +507,11 @@ TestGDA() {
   ExecTest  "pingpong"         2       1            1
   ExecTest  "pingpong"         2       8            1
   ExecTest  "pingpong"         2       32           1
+
+  # This test requires more contexts than workgroups
+  export ROCSHMEM_MAX_NUM_CONTEXTS=1024
+  ExecTest  "teamctxinfra"     2       1            1
+  unset ROCSHMEM_MAX_NUM_CONTEXTS
 }
 
 ValidateInput() {

--- a/src/team.cpp
+++ b/src/team.cpp
@@ -74,7 +74,8 @@ __host__ Team::Team(GDADevice * device, TeamInfo* team_info_wrt_parent,
       tinfo_wrt_parent(team_info_wrt_parent),
       tinfo_wrt_world(team_info_wrt_world),
       num_pes(_num_pes),
-      my_pe(_my_pe) {
+      my_pe(_my_pe),
+      mpi_comm(_mpi_comm) {
 }
 
 __host__ __device__ int Team::get_pe_in_world(int pe) {


### PR DESCRIPTION
## Motivation

gda_devel team operation would fail due to not detecting that an mpi comm was passed in

## Test Result

Ran on smc300x/bnxt-gda

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
