### PR TITLE
Cleanup/remove a2a buff

### DIFF
--- a/include/rocshmem/rocshmem_common.hpp
+++ b/include/rocshmem/rocshmem_common.hpp
@@ -88,7 +88,6 @@ typedef struct {
 } rocshmem_team_config_t;
 
 constexpr size_t ROCSHMEM_REDUCE_MIN_WRKDATA_SIZE = 1024;
-constexpr size_t ROCSHMEM_ATA_MAX_WRKDATA_SIZE = (4 * 1024 * 1024);
 constexpr size_t ROCSHMEM_BARRIER_SYNC_SIZE = 256;
 constexpr size_t ROCSHMEM_REDUCE_SYNC_SIZE = 256;
 // Internally calls sync function, which matches barrier implementation

--- a/src/gda/backend_gda.cpp
+++ b/src/gda/backend_gda.cpp
@@ -399,8 +399,7 @@ void GDABackend::setup_wrk_sync_buffer() {
    * Accommodate largest possible data type for pWrk
   */
   wrk_sync_pool_size_ += sizeof(double) * max_num_teams *
-                           (ROCSHMEM_REDUCE_MIN_WRKDATA_SIZE +
-                            ROCSHMEM_ATA_MAX_WRKDATA_SIZE);
+                           ROCSHMEM_REDUCE_MIN_WRKDATA_SIZE;
 
   /**
    * Size of fence array
@@ -477,11 +476,6 @@ void GDABackend::setup_teams() {
   /* Accommodating for largest possible data type for pWrk */
   pWrk_pool = reinterpret_cast<void *>(wrk_sync_pool_top_);
   wrk_sync_pool_top_ += sizeof(double) * ROCSHMEM_REDUCE_MIN_WRKDATA_SIZE
-                            * max_num_teams;
-
-
-  pAta_pool = reinterpret_cast<void *>(wrk_sync_pool_top_);
-  wrk_sync_pool_top_ += sizeof(double) * ROCSHMEM_ATA_MAX_WRKDATA_SIZE
                             * max_num_teams;
 
   /**

--- a/src/gda/gda_team.cpp
+++ b/src/gda/gda_team.cpp
@@ -46,7 +46,6 @@ GDATeam::GDATeam(Backend *backend, TeamInfo *team_info_parent,
   alltoall_pSync = &(b->alltoall_pSync_pool[pool_index * ROCSHMEM_ALLTOALL_SYNC_SIZE]);
 
   pWrk = reinterpret_cast<char *>(b->pWrk_pool) + ROCSHMEM_REDUCE_MIN_WRKDATA_SIZE * sizeof(double) * pool_index;
-  pAta = reinterpret_cast<char *>(b->pAta_pool) + ROCSHMEM_ATA_MAX_WRKDATA_SIZE * sizeof(double) * pool_index;
 }
 
 GDATeam::~GDATeam() {}

--- a/src/ipc/backend_ipc.cpp
+++ b/src/ipc/backend_ipc.cpp
@@ -356,8 +356,7 @@ void IPCBackend::setup_wrk_sync_buffers() {
    * Accommodate largest possible data type for pWrk
   */
   wrk_sync_pool_size_ += sizeof(double) * max_num_teams *
-                           (ROCSHMEM_REDUCE_MIN_WRKDATA_SIZE +
-                            ROCSHMEM_ATA_MAX_WRKDATA_SIZE);
+                           ROCSHMEM_REDUCE_MIN_WRKDATA_SIZE;
 
   /**
    * Size of fence array
@@ -492,11 +491,6 @@ void IPCBackend::teams_init() {
   /* Accommodating for largest possible data type for pWrk */
   pWrk_pool = reinterpret_cast<void *>(wrk_sync_pool_top_);
   wrk_sync_pool_top_ += sizeof(double) * ROCSHMEM_REDUCE_MIN_WRKDATA_SIZE
-                            * max_num_teams;
-
-
-  pAta_pool = reinterpret_cast<void *>(wrk_sync_pool_top_);
-  wrk_sync_pool_top_ += sizeof(double) * ROCSHMEM_ATA_MAX_WRKDATA_SIZE
                             * max_num_teams;
 
   /**

--- a/src/ipc/ipc_team.cpp
+++ b/src/ipc/ipc_team.cpp
@@ -46,7 +46,6 @@ IPCTeam::IPCTeam(Backend *backend, TeamInfo *team_info_parent,
   alltoall_pSync = &(b->alltoall_pSync_pool[pool_index * ROCSHMEM_ALLTOALL_SYNC_SIZE]);
 
   pWrk = reinterpret_cast<char *>(b->pWrk_pool) + ROCSHMEM_REDUCE_MIN_WRKDATA_SIZE * sizeof(double) * pool_index;
-  pAta = reinterpret_cast<char *>(b->pAta_pool) + ROCSHMEM_ATA_MAX_WRKDATA_SIZE * sizeof(double) * pool_index;
 }
 
 IPCTeam::~IPCTeam() {}

--- a/src/reverse_offload/ro_net_team.hpp
+++ b/src/reverse_offload/ro_net_team.hpp
@@ -27,8 +27,6 @@
 
 #include "team.hpp"
 
-#define MAX_ATA_BUFF_SIZE (1024 * 1024 * 128)
-
 namespace rocshmem {
 
 class Backend;


### PR DESCRIPTION
## Motivation

We allocate a large amount of memory for Alltoall pWrk buffer that actually is never used for anything. 

## Technical Details

In both IPC and GDA we allocate a large buffer in the pWrk-pSync_pool buffers. In GDA we use heap memory to allocate this buffer and that causes applications to run out of memory because the available heap size is much reduced w.r.t. ROCHSMEM_HEAP_SIZE. 

## Test Plan

Compiled GDA, IPC, RO and ran
`scripts/functional_tests/driver.sh tests/functional_tests/rocshmem_functional_tests all logs ~/hostfile2-ppn8`

`scripts/functional_tests/driver.sh tests/functional_tests/rocshmem_functional_tests gda logs-gda ~/hostfile2-ppn8`

## Test Result

Functional tests pass

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
