### PR TITLE
api: wg_create_ctx w/o options param

### DIFF
--- a/docs/api/ctx.rst
+++ b/docs/api/ctx.rst
@@ -11,7 +11,7 @@ Context management routines
 ROCSHMEM_CTX_CREATE
 -------------------
 
-.. cpp:function:: __device__ int rocshmem_wg_ctx_create(int64_t options, rocshmem_ctx_t *ctx)
+.. cpp:function:: __device__ int rocshmem_wg_ctx_create(long options, rocshmem_ctx_t *ctx)
 .. cpp:function:: __device__ int rocshmem_wg_team_create_ctx(rocshmem_team_t team, long options, rocshmem_ctx_t *ctx)
         
   :param team:    Team handle to derive the context from.

--- a/docs/api/ctx.rst
+++ b/docs/api/ctx.rst
@@ -12,7 +12,9 @@ ROCSHMEM_CTX_CREATE
 -------------------
 
 .. cpp:function:: __device__ int rocshmem_wg_ctx_create(long options, rocshmem_ctx_t *ctx)
+.. cpp:function:: __device__ int rocshmem_wg_ctx_create(rocshmem_ctx_t *ctx)
 .. cpp:function:: __device__ int rocshmem_wg_team_create_ctx(rocshmem_team_t team, long options, rocshmem_ctx_t *ctx)
+.. cpp:function:: __device__ int rocshmem_wg_team_create_ctx(rocshmem_team_t team, rocshmem_ctx_t *ctx)
         
   :param team:    Team handle to derive the context from.
   :param options: Options for context creation. Ignored in current design; use the value ``0``.

--- a/include/rocshmem/rocshmem.hpp
+++ b/include/rocshmem/rocshmem.hpp
@@ -52,7 +52,7 @@
 
 namespace rocshmem {
 
-constexpr char VERSION[] = "3.0.0";
+constexpr char VERSION[] = "3.1.0";
 
 /******************************************************************************
  **************************** HOST INTERFACE **********************************
@@ -208,7 +208,8 @@ __host__ int rocshmem_my_pe();
  *
  * @return Zero on success and nonzero otherwise.
  */
-__host__ int rocshmem_ctx_create(int64_t options, rocshmem_ctx_t *ctx);
+__host__ int rocshmem_ctx_create(long options, rocshmem_ctx_t *ctx);
+__host__ int rocshmem_ctx_create(rocshmem_ctx_t *ctx);
 
 /**
  * @brief Destroys an OpenSHMEM context.
@@ -410,11 +411,14 @@ __device__ void rocshmem_query_thread(int *provided);
  * thread returns non-zero value, the operation failed and a higher number of
  * `ROCSHMEM_MAX_NUM_CONTEXTS` is required.
  */
-__device__ ATTR_NO_INLINE int rocshmem_wg_ctx_create(int64_t options,
-                                                      rocshmem_ctx_t *ctx);
+__device__ ATTR_NO_INLINE int rocshmem_wg_ctx_create(long options,
+                                                     rocshmem_ctx_t *ctx);
+__device__ ATTR_NO_INLINE int rocshmem_wg_ctx_create(rocshmem_ctx_t *ctx);
 
 __device__ ATTR_NO_INLINE int rocshmem_wg_team_create_ctx(
     rocshmem_team_t team, long options, rocshmem_ctx_t *ctx);
+__device__ ATTR_NO_INLINE int rocshmem_wg_team_create_ctx(
+    rocshmem_team_t team, rocshmem_ctx_t *ctx);
 
 /**
  * @brief Destroys an OpenSHMEM context.

--- a/src/rocshmem.cpp
+++ b/src/rocshmem.cpp
@@ -653,7 +653,7 @@ __host__ Context *get_internal_ctx(rocshmem_ctx_t ctx) {
   return reinterpret_cast<Context *>(ctx.ctx_opaque);
 }
 
-__host__ int rocshmem_ctx_create(int64_t options, rocshmem_ctx_t *ctx) {
+__host__ int rocshmem_ctx_create(long options, rocshmem_ctx_t *ctx) {
   DPRINTF("Host function: rocshmem_ctx_create\n");
 
   void *phys_ctx;
@@ -668,7 +668,9 @@ __host__ int rocshmem_ctx_create(int64_t options, rocshmem_ctx_t *ctx) {
 
   return 0;
 }
-
+__host__ int rocshmem_ctx_create(rocshmem_ctx_t *ctx) {
+  return rocshmem_ctx_create(0, ctx);
+}
 __host__ void rocshmem_ctx_destroy(rocshmem_ctx_t ctx) {
   DPRINTF("Host function: rocshmem_ctx_destroy\n");
 

--- a/src/rocshmem_gpu.cpp
+++ b/src/rocshmem_gpu.cpp
@@ -324,6 +324,9 @@ __device__ int rocshmem_wg_ctx_create(long options, rocshmem_ctx_t *ctx) {
   __syncthreads();
   return result == true ? 0 : -1;
 }
+__device__ int rocshmem_wg_ctx_create(rocshmem_ctx_t *ctx) {
+  return rocshmem_wg_ctx_create(0, ctx);
+}
 
 __device__ int rocshmem_wg_team_create_ctx(rocshmem_team_t team, long options,
                                            rocshmem_ctx_t *ctx) {
@@ -346,6 +349,9 @@ __device__ int rocshmem_wg_team_create_ctx(rocshmem_team_t team, long options,
   __syncthreads();
 
   return result == true ? 0 : -1;
+}
+__device__ int rocshmem_wg_team_create_ctx(rocshmem_team_t team, rocshmem_ctx_t *ctx) {
+  return rocshmem_wg_team_create_ctx(team, 0, ctx);
 }
 
 __device__ void rocshmem_wg_ctx_destroy(

--- a/tests/functional_tests/sync_tester.cpp
+++ b/tests/functional_tests/sync_tester.cpp
@@ -37,7 +37,7 @@ __global__ void SyncTest(int loop, int skip, long long int *start_time,
   int wf_id = t_id / wf_size;
 
   rocshmem_wg_init();
-  rocshmem_wg_ctx_create(ctx_type, &ctx);
+  rocshmem_wg_ctx_create(&ctx);
 
   for (int i = 0; i < loop + skip; i++) {
     if (hipThreadIdx_x == 0 && i == skip) {

--- a/tests/functional_tests/team_ctx_infra_tester.cpp
+++ b/tests/functional_tests/team_ctx_infra_tester.cpp
@@ -131,6 +131,23 @@ rocshmem_team_t team_world_dup[NUM_TEAMS];
     rocshmem_wg_ctx_destroy(&ctx[team_i]);
   }
 
+  /**
+   * Test 3: Create teams using team_create_ctx w/o ctx_type.
+   */
+  for (int team_i = 0; team_i < NUM_TEAMS; team_i++) {
+    rocshmem_wg_team_create_ctx(team[team_i], &ctx[team_i]);
+    if (nullptr == ctx[team_i].ctx_opaque) {
+      printf("Create ctx (w/o ctx_type) on team[%d] returned an invalid context!\n", team_i);
+      abort();
+    }
+  }
+
+  __syncthreads();
+
+  for (int team_i = 0; team_i < NUM_TEAMS; team_i++) {
+    rocshmem_wg_ctx_destroy(&ctx[team_i]);
+  }
+
   rocshmem_wg_finalize();
 }
 


### PR DESCRIPTION
## Motivation

In the gda_devel branch we had a different API for wg_create_ctx w/o the option parameter. DeepEP customer code has been adapted to use that variant. It is best to enable compatibility with both forms going forward.

## Technical Details

Since we cannot just have an implicit initializer due to the order of parameters (only valid Right->Left), we use function overloading. 

## Test Plan

Modified team_infra tester and sync tester to use the optionless variant for test coverage

## Test Result

All tests pass in IPC (Hayabusa)

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
