### PR TITLE
Make it possible to test RMA GET and PUT separately

### DIFF
--- a/scripts/functional_tests/driver.sh
+++ b/scripts/functional_tests/driver.sh
@@ -286,9 +286,7 @@ TestRMAGet() {
 
 TestRMA() {
   TestRMAPut
-  if [ "0" == "$ROCSHMEM_DRIVER_DISABLE_GET" ]; then
-    TestRMAGet
-  fi
+  TestRMAGet
 }
 
 TestAMO() {
@@ -645,7 +643,6 @@ LOG_DIR=$3
 HOSTFILE=$4
 
 DRIVER_RETURN_STATUS=0
-ROCSHMEM_DRIVER_DISABLE_GET="${ROCSHMEM_DRIVER_DISABLE_GET:-1}"
 
 ValidateInput $#
 ValidateLogDir $LOG_DIR
@@ -663,6 +660,12 @@ case $TEST in
     ;;
   *"rma")
     TestRMA
+    ;;
+  *"put")
+    TestRMAPut
+    ;;
+  *"get")
+    TestRMAGet
     ;;
   *"amo")
     TestAMO


### PR DESCRIPTION
DISABLE_GET removed from ALL, idea is that the CI scripts will invoke a subset that is known to work rather than ALL

## Motivation

We need to have granular testing capabilities. Here we can trigger Put and Get separately. This may prove useful for CI scripts as different transports have a different set of features implemented.

Idea is that CI scripts would run explicitly the features that are known working rather than calling all. 

## Technical Details

In driver.sh: Remove DISABLE_GET, add a 'get' (and 'put') command line option so one can run put and get separately.

## Test Plan

No test plan, this presumably will need adaptations in CI scripts for RO due to removal of DISABLE_GET