### PR TITLE
add an all-ro flag

### DIFF
--- a/scripts/functional_tests/driver.sh
+++ b/scripts/functional_tests/driver.sh
@@ -657,6 +657,13 @@ case $TEST in
     TestColl
     TestOther
     ;;
+  *"all-ro")
+    TestRMAPut
+    TestAMO
+    TestSigOps
+    TestColl
+    TestOther
+    ;;
   *"rma")
     TestRMA
     ;;


### PR DESCRIPTION
to specify the subset of tests that we want to run in Jenkins with the RO conduit

## Motivation

simplifies testing of the relevant functionality for the CI
