### PR TITLE
GDA 64 bit atomics APIs

### DIFF
--- a/src/gda/context_gda_tmpl_device.hpp
+++ b/src/gda/context_gda_tmpl_device.hpp
@@ -247,8 +247,29 @@ __device__ T GDAContext::amo_fetch_or(void *dst, T value, int pe) {
 
 template <typename T>
 __device__ void GDAContext::amo_or(void *dst, T value, int pe) {
-  printf("rocshmem::gda:amo_or not implemented\n");
-  abort();
+  if constexpr (sizeof(T) != 8) { printf("rocshmem::gda:amo_or not implemented for non-64bit types.\n"); abort(); }//TODO:support for non-uint64t
+  uint64_t L_offset = reinterpret_cast<char *>(dst) - base_heap[my_pe];
+  bool need_turn {true};
+  uint64_t turns = __ballot(need_turn);
+  T ret_val;
+  T cond = 0;
+  T desired_val = cond | value;
+  while (turns) {
+    uint8_t lane = __ffsll((unsigned long long)turns) - 1;
+    int pe_turn = __shfl(pe, lane);
+    if (pe_turn == pe) {
+      while ((ret_val = qps[pe].atomic_fetch(base_heap[pe] + L_offset, desired_val,
+                                             cond, pe, GDA_OP_ATOMIC_CS))) {
+        if (ret_val == cond) {
+          need_turn = false;
+          break;
+        }
+        cond = ret_val;
+        desired_val = ret_val | value;
+      }
+    }
+    turns = __ballot(need_turn);
+  }
 }
 
 template <typename T>

--- a/src/gda/context_gda_tmpl_device.hpp
+++ b/src/gda/context_gda_tmpl_device.hpp
@@ -164,7 +164,7 @@ __device__ T GDAContext::amo_swap(void *dst, T value, int pe) {
 
 template <typename T>
 __device__ T GDAContext::amo_fetch_and(void *dst, T value, int pe) {
-  if constexpr (sizeof(T) != 8) { printf("rocshmem::gda:amo_fetch_add not implemented for non-64bit types.\n"); abort(); }//TODO:support for non-uint64t
+  if constexpr (sizeof(T) != 8) { printf("rocshmem::gda:amo_fetch_and not implemented for non-64bit types.\n"); abort(); }//TODO:support for non-uint64t
   uint64_t L_offset = reinterpret_cast<char *>(dst) - base_heap[my_pe];
   bool need_turn {true};
   uint64_t turns = __ballot(need_turn);
@@ -192,8 +192,29 @@ __device__ T GDAContext::amo_fetch_and(void *dst, T value, int pe) {
 
 template <typename T>
 __device__ void GDAContext::amo_and(void *dst, T value, int pe) {
-  printf("rocshmem::gda:amo_and not implemented\n");
-  abort();
+  if constexpr (sizeof(T) != 8) { printf("rocshmem::gda:amo_and not implemented for non-64bit types.\n"); abort(); }//TODO:support for non-uint64t
+  uint64_t L_offset = reinterpret_cast<char *>(dst) - base_heap[my_pe];
+  bool need_turn {true};
+  uint64_t turns = __ballot(need_turn);
+  T ret_val;
+  T cond = 0;
+  T desired_val = cond & value;
+  while (turns) {
+    uint8_t lane = __ffsll((unsigned long long)turns) - 1;
+    int pe_turn = __shfl(pe, lane);
+    if (pe_turn == pe) {
+      while ((ret_val = qps[pe].atomic_fetch(base_heap[pe] + L_offset, desired_val,
+                                             cond, pe, GDA_OP_ATOMIC_CS))) {
+        if (ret_val == cond) {
+          need_turn = false;
+          break;
+        }
+        cond = ret_val;
+        desired_val = ret_val & value;
+      }
+    }
+    turns = __ballot(need_turn);
+  }
 }
 
 template <typename T>

--- a/src/gda/context_gda_tmpl_device.hpp
+++ b/src/gda/context_gda_tmpl_device.hpp
@@ -164,9 +164,30 @@ __device__ T GDAContext::amo_swap(void *dst, T value, int pe) {
 
 template <typename T>
 __device__ T GDAContext::amo_fetch_and(void *dst, T value, int pe) {
-  printf("rocshmem::gda:amo_fetch_and not implemented\n");
-  abort();
-  return 0;
+  if constexpr (sizeof(T) != 8) { printf("rocshmem::gda:amo_fetch_add not implemented for non-64bit types.\n"); abort(); }//TODO:support for non-uint64t
+  uint64_t L_offset = reinterpret_cast<char *>(dst) - base_heap[my_pe];
+  bool need_turn {true};
+  uint64_t turns = __ballot(need_turn);
+  T ret_val;
+  T cond = 0;
+  T desired_val = cond & value;
+  while (turns) {
+    uint8_t lane = __ffsll((unsigned long long)turns) - 1;
+    int pe_turn = __shfl(pe, lane);
+    if (pe_turn == pe) {
+      while ((ret_val = qps[pe].atomic_fetch(base_heap[pe] + L_offset, desired_val,
+                                             cond, pe, GDA_OP_ATOMIC_CS))) {
+        if (ret_val == cond) {
+          need_turn = false;
+          break;
+        }
+        cond = ret_val;
+        desired_val = ret_val & value;
+      }
+    }
+    turns = __ballot(need_turn);
+  }
+  return ret_val;
 }
 
 template <typename T>

--- a/src/gda/context_gda_tmpl_device.hpp
+++ b/src/gda/context_gda_tmpl_device.hpp
@@ -198,9 +198,30 @@ __device__ void GDAContext::amo_and(void *dst, T value, int pe) {
 
 template <typename T>
 __device__ T GDAContext::amo_fetch_or(void *dst, T value, int pe) {
-  printf("rocshmem::gda:amo_fetch_or not implemented\n");
-  abort();
-  return 0;
+  if constexpr (sizeof(T) != 8) { printf("rocshmem::gda:amo_fetch_or not implemented for non-64bit types.\n"); abort(); }//TODO:support for non-uint64t
+  uint64_t L_offset = reinterpret_cast<char *>(dst) - base_heap[my_pe];
+  bool need_turn {true};
+  uint64_t turns = __ballot(need_turn);
+  T ret_val;
+  T cond = 0;
+  T desired_val = cond | value;
+  while (turns) {
+    uint8_t lane = __ffsll((unsigned long long)turns) - 1;
+    int pe_turn = __shfl(pe, lane);
+    if (pe_turn == pe) {
+      while ((ret_val = qps[pe].atomic_fetch(base_heap[pe] + L_offset, desired_val,
+                                             cond, pe, GDA_OP_ATOMIC_CS))) {
+        if (ret_val == cond) {
+          need_turn = false;
+          break;
+        }
+        cond = ret_val;
+        desired_val = ret_val | value;
+      }
+    }
+    turns = __ballot(need_turn);
+  }
+  return ret_val;
 }
 
 template <typename T>

--- a/src/gda/context_gda_tmpl_device.hpp
+++ b/src/gda/context_gda_tmpl_device.hpp
@@ -138,9 +138,28 @@ __device__ void GDAContext::amo_set(void *dst, T value, int pe) {
 
 template <typename T>
 __device__ T GDAContext::amo_swap(void *dst, T value, int pe) {
-  printf("rocshmem::gda:amo_swap not implemented\n");
-  abort();
-  return 0;
+  if constexpr (sizeof(T) != 8) { printf("rocshmem::gda:amo_set not implemented for non-64bit types.\n"); abort(); }//TODO:support for non-uint64t
+  uint64_t L_offset = reinterpret_cast<char *>(dst) - base_heap[my_pe];
+  bool need_turn {true};
+  uint64_t turns = __ballot(need_turn);
+  T ret_val;
+  T cond = 0;
+  while (turns) {
+    uint8_t lane = __ffsll((unsigned long long)turns) - 1;
+    int pe_turn = __shfl(pe, lane);
+    if (pe_turn == pe) {
+      while ((ret_val = qps[pe].atomic_fetch(base_heap[pe] + L_offset, value,
+                                             cond, pe, GDA_OP_ATOMIC_CS))) {
+        if (ret_val == cond) {
+          need_turn = false;
+          break;
+        }
+        cond = ret_val;
+      }
+    }
+    turns = __ballot(need_turn);
+  }
+  return ret_val;
 }
 
 template <typename T>

--- a/src/gda/context_gda_tmpl_device.hpp
+++ b/src/gda/context_gda_tmpl_device.hpp
@@ -110,13 +110,29 @@ template <typename T>
 __device__ void GDAContext::amo_set(void *dst, T value, int pe) {
   if constexpr (sizeof(T) != 8) { printf("rocshmem::gda:amo_set not implemented for non-64bit types.\n"); abort(); }//TODO:support for non-uint64t
   uint64_t L_offset = reinterpret_cast<char *>(dst) - base_heap[my_pe];
+  bool need_turn {true};
+  uint64_t turns = __ballot(need_turn);
   T ret_val;
   T cond = 0;
-  for (int i = 0; i < WF_SIZE; i++) { //TODO: this looks wrong
-    while ((ret_val = qps[pe].atomic_fetch(base_heap[pe] + L_offset, value, cond, pe, GDA_OP_ATOMIC_CS))) {
-      if (ret_val == cond) { break; }
-      cond = ret_val;
+  while (turns) {
+    uint8_t lane = __ffsll((unsigned long long)turns) - 1;
+    int pe_turn = __shfl(pe, lane);
+    if (pe_turn == pe) {
+      /**
+       * Guess that the remote memory is zero by setting condition to zero.
+       * The compare-and-swap loop will execute at least twice if wrong.
+       * It may run additional times if contention on memory location.
+       */
+      while ((ret_val = qps[pe].atomic_fetch(base_heap[pe] + L_offset, value,
+                                             cond, pe, GDA_OP_ATOMIC_CS))) {
+        if (ret_val == cond) {
+          need_turn = false;
+          break;
+        }
+        cond = ret_val;
+      }
     }
+    turns = __ballot(need_turn);
   }
 }
 

--- a/src/gda/context_gda_tmpl_device.hpp
+++ b/src/gda/context_gda_tmpl_device.hpp
@@ -331,8 +331,16 @@ template <typename T>
 __device__ void GDAContext::amo_cas(void *dst, T value, T cond, int pe) {
   if constexpr (sizeof(T) != 8) { printf("rocshmem::gda:amo_cas not implemented for non-64bit types.\n"); abort(); }//TODO:support for non-uint64t
   uint64_t L_offset = reinterpret_cast<char *>(dst) - base_heap[my_pe];
-  for (int i = 0; i < WF_SIZE; i++) { //TODO: this looks wrong
-    qps[pe].atomic_nofetch(base_heap[pe] + L_offset, value, cond, pe, GDA_OP_ATOMIC_CS);
+  bool need_turn {true};
+  uint64_t turns = __ballot(need_turn);
+  while (turns) {
+    uint8_t lane = __ffsll((unsigned long long)turns) - 1;
+    int pe_turn = __shfl(pe, lane);
+    if (pe_turn == pe) {
+      qps[pe].atomic_nofetch(base_heap[pe] + L_offset, value, cond, pe, GDA_OP_ATOMIC_CS);
+      need_turn = false;
+    }
+    turns = __ballot(need_turn);
   }
 }
 

--- a/src/gda/context_gda_tmpl_device.hpp
+++ b/src/gda/context_gda_tmpl_device.hpp
@@ -367,9 +367,17 @@ template <typename T>
 __device__ T GDAContext::amo_fetch_cas(void *dst, T value, T cond, int pe) {
   if constexpr (sizeof(T) != 8) { printf("rocshmem::gda:amo_fcas not implemented for non-64bit types.\n"); abort(); }//TODO:support for non-uint64t
   uint64_t L_offset = reinterpret_cast<char *>(dst) - base_heap[my_pe];
+  bool need_turn {true};
+  uint64_t turns = __ballot(need_turn);
   T ret_val;
-  for (int i = 0; i < WF_SIZE; i++) {
-    ret_val = qps[pe].atomic_fetch(base_heap[pe] + L_offset, value, cond, pe, GDA_OP_ATOMIC_CS);
+  while (turns) {
+    uint8_t lane = __ffsll((unsigned long long)turns) - 1;
+    int pe_turn = __shfl(pe, lane);
+    if (pe_turn == pe) {
+      ret_val = qps[pe].atomic_fetch(base_heap[pe] + L_offset, value, cond, pe, GDA_OP_ATOMIC_CS);
+      need_turn = false;
+    }
+    turns = __ballot(need_turn);
   }
   return ret_val;
 }

--- a/src/gda/context_gda_tmpl_device.hpp
+++ b/src/gda/context_gda_tmpl_device.hpp
@@ -302,8 +302,29 @@ __device__ T GDAContext::amo_fetch_xor(void *dst, T value, int pe) {
 
 template <typename T>
 __device__ void GDAContext::amo_xor(void *dst, T value, int pe) {
-  printf("rocshmem::gda:amo_xor not implemented\n");
-  abort();
+  if constexpr (sizeof(T) != 8) { printf("rocshmem::gda:amo_xor not implemented for non-64bit types.\n"); abort(); }//TODO:support for non-uint64t
+  uint64_t L_offset = reinterpret_cast<char *>(dst) - base_heap[my_pe];
+  bool need_turn {true};
+  uint64_t turns = __ballot(need_turn);
+  T ret_val;
+  T cond = 0;
+  T desired_val = cond ^ value;
+  while (turns) {
+    uint8_t lane = __ffsll((unsigned long long)turns) - 1;
+    int pe_turn = __shfl(pe, lane);
+    if (pe_turn == pe) {
+      while ((ret_val = qps[pe].atomic_fetch(base_heap[pe] + L_offset, desired_val,
+                                             cond, pe, GDA_OP_ATOMIC_CS))) {
+        if (ret_val == cond) {
+          need_turn = false;
+          break;
+        }
+        cond = ret_val;
+        desired_val = ret_val ^ value;
+      }
+    }
+    turns = __ballot(need_turn);
+  }
 }
 
 template <typename T>

--- a/src/gda/context_gda_tmpl_device.hpp
+++ b/src/gda/context_gda_tmpl_device.hpp
@@ -124,13 +124,10 @@ __device__ void GDAContext::amo_set(void *dst, T value, int pe) {
        * It may run additional times if contention on memory location.
        */
       while ((ret_val = qps[pe].atomic_fetch(base_heap[pe] + L_offset, value,
-                                             cond, pe, GDA_OP_ATOMIC_CS))) {
-        if (ret_val == cond) {
-          need_turn = false;
-          break;
-        }
+                         cond, pe, GDA_OP_ATOMIC_CS)) != cond) {
         cond = ret_val;
       }
+      need_turn = false;
     }
     turns = __ballot(need_turn);
   }
@@ -149,13 +146,10 @@ __device__ T GDAContext::amo_swap(void *dst, T value, int pe) {
     int pe_turn = __shfl(pe, lane);
     if (pe_turn == pe) {
       while ((ret_val = qps[pe].atomic_fetch(base_heap[pe] + L_offset, value,
-                                             cond, pe, GDA_OP_ATOMIC_CS))) {
-        if (ret_val == cond) {
-          need_turn = false;
-          break;
-        }
+                         cond, pe, GDA_OP_ATOMIC_CS)) != cond) {
         cond = ret_val;
       }
+      need_turn = false;
     }
     turns = __ballot(need_turn);
   }
@@ -175,15 +169,12 @@ __device__ T GDAContext::amo_fetch_and(void *dst, T value, int pe) {
     uint8_t lane = __ffsll((unsigned long long)turns) - 1;
     int pe_turn = __shfl(pe, lane);
     if (pe_turn == pe) {
-      while ((ret_val = qps[pe].atomic_fetch(base_heap[pe] + L_offset, desired_val,
-                                             cond, pe, GDA_OP_ATOMIC_CS))) {
-        if (ret_val == cond) {
-          need_turn = false;
-          break;
-        }
+      while ((ret_val = qps[pe].atomic_fetch(base_heap[pe] + L_offset,
+                         desired_val, cond, pe, GDA_OP_ATOMIC_CS)) != cond) {
         cond = ret_val;
         desired_val = ret_val & value;
       }
+      need_turn = false;
     }
     turns = __ballot(need_turn);
   }
@@ -203,15 +194,12 @@ __device__ void GDAContext::amo_and(void *dst, T value, int pe) {
     uint8_t lane = __ffsll((unsigned long long)turns) - 1;
     int pe_turn = __shfl(pe, lane);
     if (pe_turn == pe) {
-      while ((ret_val = qps[pe].atomic_fetch(base_heap[pe] + L_offset, desired_val,
-                                             cond, pe, GDA_OP_ATOMIC_CS))) {
-        if (ret_val == cond) {
-          need_turn = false;
-          break;
-        }
+      while ((ret_val = qps[pe].atomic_fetch(base_heap[pe] + L_offset,
+                         desired_val, cond, pe, GDA_OP_ATOMIC_CS)) != cond) {
         cond = ret_val;
         desired_val = ret_val & value;
       }
+      need_turn = false;
     }
     turns = __ballot(need_turn);
   }
@@ -230,15 +218,12 @@ __device__ T GDAContext::amo_fetch_or(void *dst, T value, int pe) {
     uint8_t lane = __ffsll((unsigned long long)turns) - 1;
     int pe_turn = __shfl(pe, lane);
     if (pe_turn == pe) {
-      while ((ret_val = qps[pe].atomic_fetch(base_heap[pe] + L_offset, desired_val,
-                                             cond, pe, GDA_OP_ATOMIC_CS))) {
-        if (ret_val == cond) {
-          need_turn = false;
-          break;
-        }
+      while ((ret_val = qps[pe].atomic_fetch(base_heap[pe] + L_offset,
+                         desired_val, cond, pe, GDA_OP_ATOMIC_CS)) != cond) {
         cond = ret_val;
         desired_val = ret_val | value;
       }
+      need_turn = false;
     }
     turns = __ballot(need_turn);
   }
@@ -258,15 +243,12 @@ __device__ void GDAContext::amo_or(void *dst, T value, int pe) {
     uint8_t lane = __ffsll((unsigned long long)turns) - 1;
     int pe_turn = __shfl(pe, lane);
     if (pe_turn == pe) {
-      while ((ret_val = qps[pe].atomic_fetch(base_heap[pe] + L_offset, desired_val,
-                                             cond, pe, GDA_OP_ATOMIC_CS))) {
-        if (ret_val == cond) {
-          need_turn = false;
-          break;
-        }
+      while ((ret_val = qps[pe].atomic_fetch(base_heap[pe] + L_offset,
+                         desired_val, cond, pe, GDA_OP_ATOMIC_CS)) != cond) {
         cond = ret_val;
         desired_val = ret_val | value;
       }
+      need_turn = false;
     }
     turns = __ballot(need_turn);
   }
@@ -285,15 +267,12 @@ __device__ T GDAContext::amo_fetch_xor(void *dst, T value, int pe) {
     uint8_t lane = __ffsll((unsigned long long)turns) - 1;
     int pe_turn = __shfl(pe, lane);
     if (pe_turn == pe) {
-      while ((ret_val = qps[pe].atomic_fetch(base_heap[pe] + L_offset, desired_val,
-                                             cond, pe, GDA_OP_ATOMIC_CS))) {
-        if (ret_val == cond) {
-          need_turn = false;
-          break;
-        }
+      while ((ret_val = qps[pe].atomic_fetch(base_heap[pe] + L_offset,
+                         desired_val, cond, pe, GDA_OP_ATOMIC_CS)) != cond) {
         cond = ret_val;
         desired_val = ret_val ^ value;
       }
+      need_turn = false;
     }
     turns = __ballot(need_turn);
   }
@@ -313,15 +292,12 @@ __device__ void GDAContext::amo_xor(void *dst, T value, int pe) {
     uint8_t lane = __ffsll((unsigned long long)turns) - 1;
     int pe_turn = __shfl(pe, lane);
     if (pe_turn == pe) {
-      while ((ret_val = qps[pe].atomic_fetch(base_heap[pe] + L_offset, desired_val,
-                                             cond, pe, GDA_OP_ATOMIC_CS))) {
-        if (ret_val == cond) {
-          need_turn = false;
-          break;
-        }
+      while ((ret_val = qps[pe].atomic_fetch(base_heap[pe] + L_offset,
+                         desired_val, cond, pe, GDA_OP_ATOMIC_CS)) != cond) {
         cond = ret_val;
         desired_val = ret_val ^ value;
       }
+      need_turn = false;
     }
     turns = __ballot(need_turn);
   }

--- a/src/gda/context_gda_tmpl_device.hpp
+++ b/src/gda/context_gda_tmpl_device.hpp
@@ -232,9 +232,30 @@ __device__ void GDAContext::amo_or(void *dst, T value, int pe) {
 
 template <typename T>
 __device__ T GDAContext::amo_fetch_xor(void *dst, T value, int pe) {
-  printf("rocshmem::gda:amo_fetch_xor not implemented\n");
-  abort();
-  return 0;
+  if constexpr (sizeof(T) != 8) { printf("rocshmem::gda:amo_fetch_xor not implemented for non-64bit types.\n"); abort(); }//TODO:support for non-uint64t
+  uint64_t L_offset = reinterpret_cast<char *>(dst) - base_heap[my_pe];
+  bool need_turn {true};
+  uint64_t turns = __ballot(need_turn);
+  T ret_val;
+  T cond = 0;
+  T desired_val = cond ^ value;
+  while (turns) {
+    uint8_t lane = __ffsll((unsigned long long)turns) - 1;
+    int pe_turn = __shfl(pe, lane);
+    if (pe_turn == pe) {
+      while ((ret_val = qps[pe].atomic_fetch(base_heap[pe] + L_offset, desired_val,
+                                             cond, pe, GDA_OP_ATOMIC_CS))) {
+        if (ret_val == cond) {
+          need_turn = false;
+          break;
+        }
+        cond = ret_val;
+        desired_val = ret_val ^ value;
+      }
+    }
+    turns = __ballot(need_turn);
+  }
+  return ret_val;
 }
 
 template <typename T>

--- a/src/gda/context_gda_tmpl_device.hpp
+++ b/src/gda/context_gda_tmpl_device.hpp
@@ -108,6 +108,11 @@ __device__ void GDAContext::amo_add(void *dst, T value, int pe) {
 
 template <typename T>
 __device__ void GDAContext::amo_set(void *dst, T value, int pe) {
+  amo_swap(dst, value, pe);
+}
+
+template <typename T>
+__device__ T GDAContext::amo_swap(void *dst, T value, int pe) {
   if constexpr (sizeof(T) != 8) { printf("rocshmem::gda:amo_set not implemented for non-64bit types.\n"); abort(); }//TODO:support for non-uint64t
   uint64_t L_offset = reinterpret_cast<char *>(dst) - base_heap[my_pe];
   bool need_turn {true};
@@ -123,28 +128,6 @@ __device__ void GDAContext::amo_set(void *dst, T value, int pe) {
        * The compare-and-swap loop will execute at least twice if wrong.
        * It may run additional times if contention on memory location.
        */
-      while ((ret_val = qps[pe].atomic_fetch(base_heap[pe] + L_offset, value,
-                         cond, pe, GDA_OP_ATOMIC_CS)) != cond) {
-        cond = ret_val;
-      }
-      need_turn = false;
-    }
-    turns = __ballot(need_turn);
-  }
-}
-
-template <typename T>
-__device__ T GDAContext::amo_swap(void *dst, T value, int pe) {
-  if constexpr (sizeof(T) != 8) { printf("rocshmem::gda:amo_set not implemented for non-64bit types.\n"); abort(); }//TODO:support for non-uint64t
-  uint64_t L_offset = reinterpret_cast<char *>(dst) - base_heap[my_pe];
-  bool need_turn {true};
-  uint64_t turns = __ballot(need_turn);
-  T ret_val;
-  T cond = 0;
-  while (turns) {
-    uint8_t lane = __ffsll((unsigned long long)turns) - 1;
-    int pe_turn = __shfl(pe, lane);
-    if (pe_turn == pe) {
       while ((ret_val = qps[pe].atomic_fetch(base_heap[pe] + L_offset, value,
                          cond, pe, GDA_OP_ATOMIC_CS)) != cond) {
         cond = ret_val;
@@ -183,26 +166,7 @@ __device__ T GDAContext::amo_fetch_and(void *dst, T value, int pe) {
 
 template <typename T>
 __device__ void GDAContext::amo_and(void *dst, T value, int pe) {
-  if constexpr (sizeof(T) != 8) { printf("rocshmem::gda:amo_and not implemented for non-64bit types.\n"); abort(); }//TODO:support for non-uint64t
-  uint64_t L_offset = reinterpret_cast<char *>(dst) - base_heap[my_pe];
-  bool need_turn {true};
-  uint64_t turns = __ballot(need_turn);
-  T ret_val;
-  T cond = 0;
-  T desired_val = cond & value;
-  while (turns) {
-    uint8_t lane = __ffsll((unsigned long long)turns) - 1;
-    int pe_turn = __shfl(pe, lane);
-    if (pe_turn == pe) {
-      while ((ret_val = qps[pe].atomic_fetch(base_heap[pe] + L_offset,
-                         desired_val, cond, pe, GDA_OP_ATOMIC_CS)) != cond) {
-        cond = ret_val;
-        desired_val = ret_val & value;
-      }
-      need_turn = false;
-    }
-    turns = __ballot(need_turn);
-  }
+  amo_fetch_and(dst, value, pe);
 }
 
 template <typename T>
@@ -232,26 +196,7 @@ __device__ T GDAContext::amo_fetch_or(void *dst, T value, int pe) {
 
 template <typename T>
 __device__ void GDAContext::amo_or(void *dst, T value, int pe) {
-  if constexpr (sizeof(T) != 8) { printf("rocshmem::gda:amo_or not implemented for non-64bit types.\n"); abort(); }//TODO:support for non-uint64t
-  uint64_t L_offset = reinterpret_cast<char *>(dst) - base_heap[my_pe];
-  bool need_turn {true};
-  uint64_t turns = __ballot(need_turn);
-  T ret_val;
-  T cond = 0;
-  T desired_val = cond | value;
-  while (turns) {
-    uint8_t lane = __ffsll((unsigned long long)turns) - 1;
-    int pe_turn = __shfl(pe, lane);
-    if (pe_turn == pe) {
-      while ((ret_val = qps[pe].atomic_fetch(base_heap[pe] + L_offset,
-                         desired_val, cond, pe, GDA_OP_ATOMIC_CS)) != cond) {
-        cond = ret_val;
-        desired_val = ret_val | value;
-      }
-      need_turn = false;
-    }
-    turns = __ballot(need_turn);
-  }
+  amo_fetch_or(dst, value, pe);
 }
 
 template <typename T>
@@ -281,26 +226,7 @@ __device__ T GDAContext::amo_fetch_xor(void *dst, T value, int pe) {
 
 template <typename T>
 __device__ void GDAContext::amo_xor(void *dst, T value, int pe) {
-  if constexpr (sizeof(T) != 8) { printf("rocshmem::gda:amo_xor not implemented for non-64bit types.\n"); abort(); }//TODO:support for non-uint64t
-  uint64_t L_offset = reinterpret_cast<char *>(dst) - base_heap[my_pe];
-  bool need_turn {true};
-  uint64_t turns = __ballot(need_turn);
-  T ret_val;
-  T cond = 0;
-  T desired_val = cond ^ value;
-  while (turns) {
-    uint8_t lane = __ffsll((unsigned long long)turns) - 1;
-    int pe_turn = __shfl(pe, lane);
-    if (pe_turn == pe) {
-      while ((ret_val = qps[pe].atomic_fetch(base_heap[pe] + L_offset,
-                         desired_val, cond, pe, GDA_OP_ATOMIC_CS)) != cond) {
-        cond = ret_val;
-        desired_val = ret_val ^ value;
-      }
-      need_turn = false;
-    }
-    turns = __ballot(need_turn);
-  }
+  amo_fetch_xor(dst, value, pe);
 }
 
 template <typename T>


### PR DESCRIPTION
## Motivation
- This PR adds new 64 bit atomics APIs within IBGDA for mlx and bnxt NICs.
- It extends the functionality of GDA to support additional atomics APIs

## Technical Details
- Implemented:
  - `set`, `swap`
  - `fetch_and`, `fetch_or`, `fetch_xor`
  - `and`, `or`, `xor`
  - `cas`, `fetch_cas`
- All operations are implemented using atomic compare-and-swap (CAS)
- Implements only 64 bit atomics

## Test Plan
- Unit tests for each new operation
- Multi-thread stress tests for correctness under contention

## Test Result


## Submission Checklist
- [x]  Added tests for all new operations
- [x]  Verified on multiple platforms
