### PR TITLE
Improve qp mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,10 +125,14 @@ rocSHMEM has the following enviroment variables:
                         Disables IPC support for the reverse offload backend.
 
     ROCSHMEM_MAX_NUM_CONTEXTS (default : 1024)
-                        Maximum number of contexts used in library
+                        Maximum number of contexts used in library.
 
     ROCSHMEM_MAX_NUM_TEAMS (default : 40)
-                        Maximum number of teams supported by the library
+                        Maximum number of teams supported by the library.
+
+    ROCSHMEM_GDA_ALTERNATE_QP_PORTS (default : 1)
+                        Enables/Disables having QPs alternate their mappings
+                        across rocSHMEM contexts.
 ```
 
 ## Examples

--- a/docs/compile_and_run.rst
+++ b/docs/compile_and_run.rst
@@ -89,4 +89,4 @@ You can control the behavior of rocSHMEM by using the following environment vari
       - Defines whether to force using the RO conduit even when IPC is available.
     * - ROCSHMEM_GDA_ALTERNATE_QP_PORTS
       - 1
-      - Enables/Disables having QPs alternate their mappings across rocSHMEM contexts.
+      - Enables/Disables having QPs alternate their mappings across rocSHMEM contexts. This helps saturate bandwidth on multiport bonded interfaces.

--- a/docs/compile_and_run.rst
+++ b/docs/compile_and_run.rst
@@ -15,10 +15,10 @@ Compiling and linking with rocSHMEM
 
 rocSHMEM is a library that can be statically linked to your application during compilation with ``hipcc``. For more information, see :doc:`HIPCC <hipcc:index>`.
 
-When compiling your application with ``hipcc``, you must include the rocSHMEM header files and the rocSHMEM library. 
+When compiling your application with ``hipcc``, you must include the rocSHMEM header files and the rocSHMEM library.
 Because rocSHMEM depends on MPI (Message Passing Interface), you must manually add the arguments for MPI linkage instead of using ``mpicc``.
 
-When using ``hipcc`` directly without a build system, it's recommended to perform the compilation and linking steps separately. 
+When using ``hipcc`` directly without a build system, it's recommended to perform the compilation and linking steps separately.
 
 Example compile and link commands are provided at the top of the example files in the ``examples`` directory:
 
@@ -36,13 +36,13 @@ Example compile and link commands are provided at the top of the example files i
     $OPENMPI_UCX_INSTALL_DIR/lib/libmpi.so                                        \
     -L/opt/rocm/lib -lamdhip64 -lhsa-runtime64
 
-If your project uses CMake, see 
+If your project uses CMake, see
 `Using CMake with AMD ROCm <https://rocmdocs.amd.com/en/latest/conceptual/cmake-packages.html>`_.
 
 Running a rocSHMEM application
 --------------------------
 
-Applications using rocSHMEM typically deploy multiple processes, usually one per GPU.  
+Applications using rocSHMEM typically deploy multiple processes, usually one per GPU.
 The MPI launcher, for example, ``mpiexec`` with Open MPI, is used to start the required number
 of processes. For example, to launch two ``getmem`` example processes (available when compiled from source):
 
@@ -87,3 +87,6 @@ You can control the behavior of rocSHMEM by using the following environment vari
     * - ROCSHMEM_RO_DISABLE_IPC
       - 0
       - Defines whether to force using the RO conduit even when IPC is available.
+    * - ROCSHMEM_GDA_ALTERNATE_QP_PORTS
+      - 1
+      - Enables/Disables having QPs alternate their mappings across rocSHMEM contexts.

--- a/src/gda/backend_gda.cpp
+++ b/src/gda/backend_gda.cpp
@@ -144,6 +144,10 @@ void GDABackend::read_env() {
   if ((value = getenv("ROCSHMEM_SQ_SIZE"))) {
     sq_size = atoi(value);
   }
+
+  if ((value = getenv("ROCSHMEM_GDA_ALTERNATE_QP_PORTS"))) {
+    alternate_qp_ports_enabled = atoi(value);
+  }
 }
 
 void GDABackend::setup_ipc() {
@@ -937,6 +941,57 @@ void GDABackend::create_queues() {
   } else {
     create_cqs(ncqes);
     create_qps(sq_size);
+  }
+
+  alternate_qp_ports();
+}
+
+void GDABackend::alternate_qp_ports() {
+  int cur_qp_idx;
+  int new_qp_idx;
+
+  /* We can't remap anything */
+  if (maximum_num_contexts_ == 1) {
+    return;
+  }
+
+  if (alternate_qp_ports_enabled) {
+    /* If we assume two PEs and a default context and two user context,
+     * initially QPs are in the following port order:
+     *
+     * Labels :| DCTX PE0 | DCTX PE1 | CTX0 PE0 | CTX0 PE1 | CTX1 PE0 | CTX1 PE1 |
+     * QPs    :| QP0      | QP1      | QP2      | QP3      | QP4      | QP5      |
+     * Port   :| 0        | 1        | 0        | 1        | 0        | 1        |
+     *
+     * This creates the pattern where PE1 is always mapped to port 0 but we want it
+     * to use both ports to maximize throughput/bandwidth.
+     *
+     * So we reorder our QPs
+     *
+     * Labels :| DCTX PE0 | DCTX PE1 | CTX0 PE0 | CTX0 PE1 | CTX1 PE0 | CTX1 PE1 |
+     * QPs    :| QP0      | QP1      | QP2      | QP4      | QP3      | QP5      |
+     * Port   :| 0        | 1        | 1        | 0        | 0        | 1        |
+     *
+     * We alternate the ports [0,1] and [1,0] for each context.
+     * Therefore, when we use two contexts we use both ports
+     *
+     */
+
+    /* Re-Map each context */
+    for (int i = 1; i < (maximum_num_contexts_ + 1); i+=2) {
+      for (int p = 0; p < num_pes; p+=2) {
+        cur_qp_idx = (i * num_pes) + p;
+        new_qp_idx = cur_qp_idx + 1;
+
+        if (new_qp_idx < qps.size()) {
+          // Swap QPs
+          std::swap(cqs[cur_qp_idx],      cqs[new_qp_idx]);
+          std::swap(qps[cur_qp_idx],      qps[new_qp_idx]);
+          std::swap(bnxt_cqs[cur_qp_idx], bnxt_cqs[new_qp_idx]);
+          std::swap(bnxt_qps[cur_qp_idx], bnxt_qps[new_qp_idx]);
+        }
+      }
+    }
   }
 }
 

--- a/src/gda/backend_gda.hpp
+++ b/src/gda/backend_gda.hpp
@@ -127,6 +127,7 @@ class GDABackend : public Backend {
   std::vector<ibv_qp*> qps;
   std::vector<ibv_cq*> cqs;
   std::vector<dest_info_t> dest_info;
+  int alternate_qp_ports_enabled = 1;;
 
   /* GDA_BNXT START */
   std::vector<struct bnxt_host_qp> bnxt_qps;
@@ -375,6 +376,11 @@ class GDABackend : public Backend {
    */
   void create_qps(int sq_length);
   void bnxt_create_qps(int sq_length);
+
+  /**
+   * @brief Reorders QPs to that we map rocSHMEM contexts to the correct QPs
+   */
+  void alternate_qp_ports();
 
   /**
    * @brief Exchange QP information for connection


### PR DESCRIPTION
## Motivation

Mapping of QPs to the correct port is critical for performance.

## Technical Details

If we create 4 QPs, the hardware will bind them to ports [0, 1, 0, 1]. These ports need to be mapped to rocSHMEM context for performance.

The default behaviour was mapping all PE_0's  to Port 0, same for PE_1

The new mapping:
- See comment in code

## Performance

`ROCSHMEM_GDA_ALTERNATE_QP_PORTS=0`

```
### Creating Test: Blocking WAVE level Puts ###                                                            
# Size (B)     # of timed Msgs        Latency (us)    Bandwidth (GB/s)    Msg Rate (Msg/s)
1              20                            11.01                0.00            90797.66
2              20                             9.43                0.00           106005.19
4              20                             9.72                0.00           102896.54
8              20                             9.67                0.00           103407.27
16             20                            10.00                0.00            99975.01
32             20                             9.76                0.00           102506.28
64             20                            10.26                0.01            97432.65
128            20                            11.17                0.01            89529.52
256            20                            11.51                0.02            86869.65
512            20                             9.94                0.05           100639.06
1024           20                             9.87                0.10           101332.52
2048           20                            11.08                0.17            90273.08
4096           20                            11.17                0.34            89561.60
8192           20                            10.92                0.70            91562.51
16384          20                            11.43                1.33            87469.93
32768          20                            10.76                2.84            92949.76
65536          20                            13.04                4.68            76666.54
131072         20                            13.25                9.21            75457.46
262144         20                            16.31               14.97            61321.48
524288         20                            26.72               18.27            37425.85
1048576        20                            46.62               20.95            21450.25
2097152        20                            86.86               22.49            11512.71
4194304        20                           172.03               22.71             5812.86
8388608        20                           346.55               22.54             2885.58
16777216       20                           686.84               22.75             1455.95
33554432       20                          1369.81               22.81              730.03
```
`ROCSHMEM_GDA_ALTERNATE_QP_PORTS=1`
```
# Size (B)     # of timed Msgs        Latency (us)    Bandwidth (GB/s)    Msg Rate (Msg/s)
1              20                            10.01                0.00            99880.14
2              20                            10.01                0.00            99940.04
4              20                            10.21                0.00            97924.01
8              20                             9.42                0.00           106202.21
16             20                            10.71                0.00            93353.25
32             20                            10.24                0.00            97618.12
64             20                            10.41                0.01            96098.40
128            20                            10.20                0.01            98020.00
256            20                            10.21                0.02            97981.58
512            20                            10.39                0.05            96227.87
1024           20                            10.65                0.09            93879.08
2048           20                            10.03                0.19            99700.90
4096           20                            11.43                0.33            87504.38
8192           20                             9.98                0.76           100180.32
16384          20                            10.63                1.44            94055.68
32768          20                            11.17                2.73            89541.55
65536          20                            12.77                4.78            78320.80
131072         20                            13.85                8.81            72202.17
262144         20                            16.42               14.87            60893.92
524288         20                            21.48               22.73            46559.27
1048576        20                            33.54               29.11            29811.59
2097152        20                            53.70               36.37            18622.67
4194304        20                            96.13               40.63            10402.36
8388608        20                           182.20               42.88             5488.41
16777216       20                           354.35               44.09             2822.07
33554432       20                           695.98               44.90             1436.83
```

## Test Result
- [x] Test BNXT
- [x] Test MLX5


