### PR TITLE
[Bug] Fix rocshmem_p and rocshmem_g functional tests

### DIFF
--- a/tests/functional_tests/primitive_tester.cpp
+++ b/tests/functional_tests/primitive_tester.cpp
@@ -82,16 +82,14 @@ __global__ void PrimitiveTest(int loop, int skip, long long int *start_time,
         rocshmem_ctx_putmem_nbi(ctx, dest, source, size, 1);
         break;
       case PTestType:
-        for (int s = 0; s < size; s++) {
-          char val = source[s];
-          rocshmem_ctx_char_p(ctx, &dest[s], val, 1);
+        {
+          /* Assigment required to verify we can send non-symetric memory */
+          char val = *source;
+          rocshmem_ctx_char_p(ctx, dest, val, 1);
         }
         break;
       case GTestType:
-        for (int s = 0; s < size; s++) {
-          char ret = rocshmem_ctx_char_g(ctx, &source[s], 1);
-          dest[s] = ret;
-        }
+        *dest = rocshmem_ctx_char_g(ctx, source, 1);
         break;
       default:
         break;

--- a/tests/functional_tests/tester_arguments.cpp
+++ b/tests/functional_tests/tester_arguments.cpp
@@ -121,6 +121,10 @@ TesterArguments::TesterArguments(int argc, char *argv[]) {
     case PutNBIMRTestType:
       min_msg_size = max_msg_size;
       break;
+    case PTestType:
+    case GTestType:
+      min_msg_size = 1;
+      max_msg_size = 1;
     default:
       break;
   }


### PR DESCRIPTION
## Bug

1. For our rocshmem_p and rocshmem_g functional tests we were calling `rocshmem_ctx_char_p/g` in a for loop relative to its size. 
2. This API only sends the size of the datatype
3. Our Latency/Bandwidth/Msg Rate values are then artificially high as do not account for the for loop
4. We also claim that we can send large data with `*_p` APIs.

## Before
```
### Creating Test: P Test ###
# Size (B)     # of timed Msgs        Latency (us)    Bandwidth (GB/s)    Msg Rate (Msg/s)
1              20                            16.93                0.00            59059.77
2              20                            32.89                0.00            30402.53
4              20                            64.37                0.00            15534.70
8              20                           129.82                0.00             7703.21
16             20                           260.23                0.00             3842.72
32             20                           514.44                0.00             1943.86
64             20                          1011.52                0.00              988.61
128            20                          2092.37                0.00              477.93
256            20                          4102.05                0.00              243.78
512            20                          8043.96                0.00              124.32
1024           20                         16004.14                0.00               62.48
2048           20                         33085.10                0.00               30.23
```

## After
```
### Creating Test: P Test ###
# Size (B)     # of timed Msgs        Latency (us)    Bandwidth (GB/s)    Msg Rate (Msg/s)
1              20                            14.62                0.00            68408.81
```