### PR TITLE
feat: Atomic CAS support for bnxt NICs

### DIFF
--- a/src/gda/bnxt/queue_pair_bnxt.cpp
+++ b/src/gda/bnxt/queue_pair_bnxt.cpp
@@ -377,6 +377,7 @@ __device__ uint64_t QueuePair::bnxt_post_wqe_amo(int pe, int32_t length, uintptr
 
       /* Populate AMO Segment */
       amo.swp_dt = atomic_data;
+      amo.cmp_dt = atomic_cmp;
 
       /* Populate SG Segment - (Return address of atomic) */
       if (fetching) {


### PR DESCRIPTION
## Motivation
Add CAS support for bnxt NICs.

## Technical Details
Include comparison data for CAS operations in the WQEs.

## Test Plan
Tested with PRs #254 and #262.

## Test Results
All CAS-based atomic operations passed with #254 and #262.

## Submission Checklist
- [x] Validate on BNXT machines
- [x] Merge after #254
