### PR TITLE
Add host API for enqueuing barrier on given stream

### DIFF
--- a/include/rocshmem/rocshmem.hpp
+++ b/include/rocshmem/rocshmem.hpp
@@ -328,6 +328,13 @@ __host__ void rocshmem_quiet();
 __host__ void rocshmem_barrier_all();
 
 /**
+ * @brief enqueues a collective barrier on given stream.
+ *
+ * @return void
+ */
+__host__ void rocshmem_barrier_all_on_stream(hipStream_t stream);
+
+/**
  * @brief registers the arrival of a PE at a barrier.
  * The caller is blocked until the synchronization is resolved.
  *

--- a/include/rocshmem/rocshmem_COLL.hpp
+++ b/include/rocshmem/rocshmem_COLL.hpp
@@ -599,6 +599,12 @@ __host__ int rocshmem_ctx_double_prod_reduce(
     rocshmem_ctx_t ctx, rocshmem_team_t team, double *dest, const double *source,
     int nreduce);
 
+/**
+ * @brief kernel for performing a barrier synchronization.
+ * Caller enqueues the kernel on given stream
+ *
+ * @return void
+ */
 __global__ ATTR_NO_INLINE void rocshmem_barrier_all_kernel();
 
 /**

--- a/include/rocshmem/rocshmem_COLL.hpp
+++ b/include/rocshmem/rocshmem_COLL.hpp
@@ -599,6 +599,8 @@ __host__ int rocshmem_ctx_double_prod_reduce(
     rocshmem_ctx_t ctx, rocshmem_team_t team, double *dest, const double *source,
     int nreduce);
 
+__global__ ATTR_NO_INLINE void rocshmem_barrier_all_kernel();
+
 /**
  * @brief perform a collective barrier between all PEs in the system.
  * The caller is blocked until the barrier is resolved.

--- a/src/context.hpp
+++ b/src/context.hpp
@@ -393,6 +393,8 @@ class Context {
 
   __host__ void barrier_all();
 
+  __host__ void barrier_all_on_stream(hipStream_t stream);
+
   __host__ void sync_all();
 
   template <typename T>

--- a/src/context_host.cpp
+++ b/src/context_host.cpp
@@ -115,4 +115,10 @@ __host__ void Context::barrier_all() {
   HOST_DISPATCH(barrier_all());
 }
 
+__host__ void Context::barrier_all_on_stream(hipStream_t stream) {
+  ctxHostStats.incStat(NUM_HOST_BARRIER_ALL);
+
+  HOST_DISPATCH(barrier_all_on_stream(stream));
+}
+
 }  // namespace rocshmem

--- a/src/host/host.cpp
+++ b/src/host/host.cpp
@@ -336,16 +336,12 @@ __host__ void HostInterface::barrier_all(WindowInfo* window_info) {
 }
 
 __host__ void HostInterface::barrier_all_on_stream(hipStream_t stream) {
-  // launch kernel to do barrier with given stream
-  // hipLaunchKernelGGL(rocshmem_barrier_all_kernel, dim3(1), dim3(1), 0, stream);
-
+  // launch kernel to do barrier with given stream, if non, use default stream
   if (stream == nullptr) {
     stream = hipStreamDefault;
   }
 
   rocshmem_barrier_all_kernel<<<1, 1, 0,  stream>>>();
-
-  // hipStreamSynchronize(stream);
 }
 
 

--- a/src/host/host.cpp
+++ b/src/host/host.cpp
@@ -335,6 +335,20 @@ __host__ void HostInterface::barrier_all(WindowInfo* window_info) {
   return;
 }
 
+__host__ void HostInterface::barrier_all_on_stream(hipStream_t stream) {
+  // launch kernel to do barrier with given stream
+  // hipLaunchKernelGGL(rocshmem_barrier_all_kernel, dim3(1), dim3(1), 0, stream);
+
+  if (stream == nullptr) {
+    stream = hipStreamDefault;
+  }
+
+  rocshmem_barrier_all_kernel<<<1, 1, 0,  stream>>>();
+
+  // hipStreamSynchronize(stream);
+}
+
+
 __host__ void HostInterface::barrier_for_sync() {
   if (host_comm_world_ != MPI_COMM_NULL) {
     MPI_Barrier(host_comm_world_);

--- a/src/host/host.hpp
+++ b/src/host/host.hpp
@@ -194,6 +194,8 @@ class HostInterface {
   __host__ void quiet(WindowInfo* window_info);
 
   __host__ void barrier_all(WindowInfo* window_info);
+  
+  __host__ void barrier_all_on_stream(hipStream_t stream);
 
   __host__ void barrier_for_sync();
 

--- a/src/ipc/context_ipc_host.cpp
+++ b/src/ipc/context_ipc_host.cpp
@@ -103,4 +103,8 @@ __host__ void IPCHostContext::barrier_all() {
   host_interface->barrier_all(context_window_info);
 }
 
+__host__ void IPCHostContext::barrier_all_on_stream(hipStream_t stream) {
+  host_interface->barrier_all_on_stream(stream);
+}
+
 }  // namespace rocshmem

--- a/src/ipc/context_ipc_host.hpp
+++ b/src/ipc/context_ipc_host.hpp
@@ -82,6 +82,8 @@ class IPCHostContext : public Context {
 
   __host__ void barrier_all();
 
+  __host__ void barrier_all_on_stream(hipStream_t stream);
+
   __host__ void sync_all();
 
   template <typename T>

--- a/src/rocshmem.cpp
+++ b/src/rocshmem.cpp
@@ -882,6 +882,13 @@ __host__ void rocshmem_barrier_all() {
   get_internal_ctx(ROCSHMEM_HOST_CTX_DEFAULT)->barrier_all();
 }
 
+
+__host__ void rocshmem_barrier_all_on_stream(hipStream_t stream) {
+  DPRINTF("Host function: rocshmem_barrier_all_on_stream\n");
+
+  get_internal_ctx(ROCSHMEM_HOST_CTX_DEFAULT)->barrier_all_on_stream(stream);
+}
+
 __host__ void rocshmem_sync_all() {
   DPRINTF("Host function: rocshmem_sync_all\n");
 

--- a/src/rocshmem_gpu.cpp
+++ b/src/rocshmem_gpu.cpp
@@ -622,6 +622,11 @@ __device__ int rocshmem_test(T *ivars, int cmp, T val) {
   return ctx_internal->test(ivars, cmp, val);
 }
 
+__global__ ATTR_NO_INLINE void rocshmem_barrier_all_kernel(){
+  rocshmem_barrier_all();
+}
+
+
 __device__ void rocshmem_barrier_all() {
   GPU_DPRINTF("Function: rocshmem_barrier_all (ctx=%zd)\n",
     get_internal_ctx(ROCSHMEM_CTX_DEFAULT));


### PR DESCRIPTION
## Motivation

Triton-dist has usecase to issue barrier on specific stream in case of ag + gemm and other such workloads when comp and comm are running on separate streams.

## Technical Details

This change adds host side api to launch a kernel on a stream to issue barrier_all device kernel.

## Test Plan

Tested as part of triton-dist integration

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
