### PR TITLE
update to build system:

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,7 +59,6 @@ option(USE_SHARED_CTX "Request support for shared ctx between WG" OFF)
 option(USE_SINGLE_NODE "Enable single node support only." OFF)
 option(USE_HDP_FLUSH "Force flush the HDP cache." OFF)
 option(USE_HDP_FLUSH_HOST_SIDE "Use a polling thread to flush the HDP cache on the host." OFF)
-option(USE_EXTERNAL_MPI "Link with an external MPI (required if used MPI is ABI incompatible with Open MPI v5" OFF)
 
 option(BUILD_FUNCTIONAL_TESTS "Build the functional tests (Requires MPI)" OFF)
 option(BUILD_EXAMPLES "Build the examples" ON)
@@ -73,6 +72,9 @@ option(BUILD_CODE_COVERAGE "Build with code coverage flags (gcc only)" OFF)
 option(GDA_IONIC "Build for AMD Pensando IONIC RDMA provider" OFF)
 option(GDA_BNXT "Build for Broadcom RDMA provider" OFF)
 option(GDA_MLX5 "Build for Mellanox MLX5 RDMA provider" OFF)
+
+set(USE_EXTERNAL_MPI AUTO CACHE STRING "Link with an external MPI (required if used MPI is ABI incompatible with Open MPI v5)")
+set_property(CACHE USE_EXTERNAL_MPI PROPERTY STRINGS AUTO ON OFF)
 
 ###############################################################################
 # PROJECT
@@ -151,7 +153,12 @@ if (NOT BUILD_TESTS_ONLY)
   #############################################################################
   # PACKAGE DEPENDENCIES
   #############################################################################
-  find_package(MPI)
+  if (NOT USE_EXTERNAL_MPI STREQUAL "OFF")
+    find_package(MPI)
+  else()
+    message ("-- External MPI detection disabled by user")
+  endif()
+
   if (MPI_FOUND)
     set(HAVE_EXTERNAL_MPI ON)
   else()

--- a/cmake/rocshmem_config.h.in
+++ b/cmake/rocshmem_config.h.in
@@ -45,5 +45,4 @@
 #cmakedefine GDA_IONIC
 #cmakedefine GDA_BNXT
 #cmakedefine GDA_MLX5
-#cmakedefine USE_EXTERNAL_MPI
 #cmakedefine HAVE_EXTERNAL_MPI

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -29,7 +29,6 @@ cmake_minimum_required(VERSION 3.16.3 FATAL_ERROR)
 include(${CMAKE_SOURCE_DIR}/cmake/setup_project.cmake)
 project(rocshmem_examples VERSION 1.0.0 LANGUAGES CXX)
 
-find_package(MPI)
 find_package(hip REQUIRED PATHS /opt/rocm)
 if (NOT TARGET roc::rocshmem)
   find_package(rocshmem REQUIRED PATHS /opt/rocm)

--- a/tests/functional_tests/CMakeLists.txt
+++ b/tests/functional_tests/CMakeLists.txt
@@ -73,8 +73,6 @@ target_sources(
 ###############################################################################
 if (BUILD_TESTS_ONLY)
   #TODO check that build_test_only still works with external-mpi
-  #find_package(MPI REQUIRED)
-  #find_package(hip REQUIRED PATHS /opt/rocm)
   find_package(rocshmem REQUIRED PATHS /opt/rocm)
 
   target_include_directories(
@@ -97,5 +95,5 @@ target_link_libraries(
   ${PROJECT_NAME}
   PRIVATE
     roc::rocshmem
-    PMIx::pmix
+    $<$<BOOL:${PMIx_FOUND}>:PMIx::pmix>
 )


### PR DESCRIPTION
## Motivation
- make adding PMIx library to compile time based on the result of finding PMIx support. This is required eg if compiling rocSHMEM with ompi 4.0/4.1, which do not have a built-in PMIx version.
- add a new option USE_EXTERNAL_MPI=OFF which ensures that we do not check for external MPI libraries (even if one would be available).

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
