### PR TITLE
Add pensando as an alias to ionic GDA selector; Print an error and quit cleanly if GDA required but could not init

### DIFF
--- a/src/gda/backend_gda.cpp
+++ b/src/gda/backend_gda.cpp
@@ -533,11 +533,11 @@ GDAProvider GDABackend::requested_provider() {
   std::string envstr = envvar::gda::provider;
   std::transform(envstr.begin(), envstr.end(), envstr.begin(), ::tolower);
   if (!envstr.empty()) {
-    printf("Found environment variable ROCSHMEM_GDA_PROVIDER, value is %s\n", envstr.c_str());
+    DPRINTF("Found environment variable ROCSHMEM_GDA_PROVIDER, value is %s\n", envstr.c_str());
     if (envstr.find("bnxt") != std::string::npos) {
       return GDAProvider::BNXT;
     }
-    if (envstr.find("ionic") != std::string::npos) {
+    if (envstr.find("ionic") != std::string::npos || envstr.find("pensando") != std::string::npos) {
       return GDAProvider::IONIC;
     }
     if (envstr.find("mlx5") != std::string::npos) {
@@ -710,8 +710,8 @@ void GDABackend::open_dv_libs() {
 #endif // defined(GDA_MLX5)
 
   if (gda_provider == GDAProvider::UNSET) {
-    printf("Initializing rocSHMEM with IONIC, BNXT, or MLX5 GDA support failed: no DV library found\n");
-    abort();
+    printf("rocshmem::gda:open_dv_libs: no DV library could dlopen for IONIC, BNXT, or MLX5 GDA support\n");
+    exit(1);
   }
 }
 


### PR DESCRIPTION
## Motivation

* ionic is the driver name, the product line name is pensando. 
* don't abort, its not a but, but a normal runtime error. 

## Technical Details

* [x] passing pensando works as intended
* [x] error gets printed when asked to run on the wrong GDA provider with envvar

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
