### PR TITLE
minor change to MPI detection logic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -168,7 +168,7 @@ if (NOT BUILD_TESTS_ONLY)
     set(BUILD_UNIT_TESTS OFF)
   endif()
 
-  if (USE_EXTERNAL_MPI)
+  if (USE_EXTERNAL_MPI STREQUAL "ON")
     if(NOT HAVE_EXTERNAL_MPI)
       message(FATAL_ERROR "External MPI support requested but MPI support not found. Build Aborted")
     endif()


### PR DESCRIPTION
## Motivation

somehow the test whether we requested MPI support or not stopped working, although no obvious code change can be located.

## Technical Details

Make the if-statement more stringent by explicitely testing whether USE_MPI_SUPPORT is "ON".

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
