### PR TITLE
functional_tests: loop count option, disable invalid atomics

### DIFF
--- a/tests/functional_tests/tester.cpp
+++ b/tests/functional_tests/tester.cpp
@@ -245,85 +245,85 @@ std::vector<Tester*> Tester::create(TesterArguments args) {
       if (rank == 0) std::cout << "AMO Fetch_Add ###" << std::endl;
       testers.push_back(new AMOStandardTester<long long>(args));
       testers.push_back(new AMOStandardTester<long>(args));
-      testers.push_back(new AMOStandardTester<int>(args));
+      //testers.push_back(new AMOStandardTester<int>(args));
       return testers;
     case AMO_FIncTestType:
       if (rank == 0) std::cout << "AMO Fetch_Inc ###" << std::endl;
       testers.push_back(new AMOStandardTester<long long>(args));
       testers.push_back(new AMOStandardTester<long>(args));
-      testers.push_back(new AMOStandardTester<int>(args));
+      //testers.push_back(new AMOStandardTester<int>(args));
       return testers;
     case AMO_FetchTestType:
       if (rank == 0) std::cout << "AMO Fetch ###" << std::endl;
       testers.push_back(new AMOExtendedTester<long long>(args));
       testers.push_back(new AMOExtendedTester<long>(args));
-      testers.push_back(new AMOExtendedTester<int>(args));
+      //testers.push_back(new AMOExtendedTester<int>(args));
       return testers;
     case AMO_FCswapTestType:
       if (rank == 0) std::cout << "AMO Fetch_CSWAP ###" << std::endl;
       testers.push_back(new AMOStandardTester<long long>(args));
       testers.push_back(new AMOStandardTester<long>(args));
-      testers.push_back(new AMOStandardTester<int>(args));
+      //testers.push_back(new AMOStandardTester<int>(args));
       return testers;
     case AMO_AddTestType:
       if (rank == 0) std::cout << "AMO Add ###" << std::endl;
       testers.push_back(new AMOStandardTester<long long>(args));
       testers.push_back(new AMOStandardTester<long>(args));
-      testers.push_back(new AMOStandardTester<int>(args));
+      //testers.push_back(new AMOStandardTester<int>(args));
       return testers;
     case AMO_SetTestType:
       if (rank == 0) std::cout << "AMO Set ###" << std::endl;
       testers.push_back(new AMOExtendedTester<long long>(args));
       testers.push_back(new AMOExtendedTester<long>(args));
-      testers.push_back(new AMOExtendedTester<int>(args));
+      //testers.push_back(new AMOExtendedTester<int>(args));
       return testers;
     case AMO_SwapTestType:
       if (rank == 0) std::cout << "AMO Swap ###" << std::endl;
       testers.push_back(new AMOExtendedTester<long long>(args));
       testers.push_back(new AMOExtendedTester<long>(args));
-      testers.push_back(new AMOExtendedTester<int>(args));
+      //testers.push_back(new AMOExtendedTester<int>(args));
       return testers;
     case AMO_FetchAndTestType:
       if (rank == 0) std::cout << "AMO Fetch And ###" << std::endl;
       testers.push_back(new AMOBitwiseTester<unsigned long long>(args));
       testers.push_back(new AMOBitwiseTester<unsigned long>(args));
-      testers.push_back(new AMOBitwiseTester<unsigned int>(args));
+      //testers.push_back(new AMOBitwiseTester<unsigned int>(args));
       return testers;
     case AMO_AndTestType:
       if (rank == 0) std::cout << "AMO And ###" << std::endl;
       testers.push_back(new AMOBitwiseTester<unsigned long long>(args));
       testers.push_back(new AMOBitwiseTester<unsigned long>(args));
-      testers.push_back(new AMOBitwiseTester<unsigned int>(args));
+      //testers.push_back(new AMOBitwiseTester<unsigned int>(args));
       return testers;
     case AMO_FetchOrTestType:
       if (rank == 0) std::cout << "AMO Fetch Or ###" << std::endl;
       testers.push_back(new AMOBitwiseTester<unsigned long long>(args));
       testers.push_back(new AMOBitwiseTester<unsigned long>(args));
-      testers.push_back(new AMOBitwiseTester<unsigned int>(args));
+      //testers.push_back(new AMOBitwiseTester<unsigned int>(args));
       return testers;
     case AMO_OrTestType:
       if (rank == 0) std::cout << "AMO Or ###" << std::endl;
       testers.push_back(new AMOBitwiseTester<unsigned long long>(args));
       testers.push_back(new AMOBitwiseTester<unsigned long>(args));
-      testers.push_back(new AMOBitwiseTester<unsigned int>(args));
+      //testers.push_back(new AMOBitwiseTester<unsigned int>(args));
       return testers;
     case AMO_FetchXorTestType:
       if (rank == 0) std::cout << "AMO Fetch Xor ###" << std::endl;
       testers.push_back(new AMOBitwiseTester<unsigned long long>(args));
       testers.push_back(new AMOBitwiseTester<unsigned long>(args));
-      testers.push_back(new AMOBitwiseTester<unsigned int>(args));
+      //testers.push_back(new AMOBitwiseTester<unsigned int>(args));
       return testers;
     case AMO_XorTestType:
       if (rank == 0) std::cout << "AMO Xor ###" << std::endl;
       testers.push_back(new AMOBitwiseTester<unsigned long long>(args));
       testers.push_back(new AMOBitwiseTester<unsigned long>(args));
-      testers.push_back(new AMOBitwiseTester<unsigned int>(args));
+      //testers.push_back(new AMOBitwiseTester<unsigned int>(args));
       return testers;
     case AMO_IncTestType:
       if (rank == 0) std::cout << "AMO Inc ###" << std::endl;
       testers.push_back(new AMOStandardTester<long long>(args));
       testers.push_back(new AMOStandardTester<long>(args));
-      testers.push_back(new AMOStandardTester<int>(args));
+      //testers.push_back(new AMOStandardTester<int>(args));
       return testers;
     case PingPongTestType:
       if (rank == 0) std::cout << "PingPong ###" << std::endl;


### PR DESCRIPTION
## Motivation

The disabled atomic tests fail assert of size.

## Technical Details

Disable atomic invalid sizes.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
- [x] Run atomic functional tests, observe normal exit without assert.