### PR TITLE
[GDA] Implement internal_direct_barrier_wg

### DIFF
--- a/src/gda/context_gda_device.hpp
+++ b/src/gda/context_gda_device.hpp
@@ -267,6 +267,9 @@ class GDAContext : public Context {
   __device__ void internal_direct_barrier(int pe, int PE_start, int stride,
                                           int n_pes, int64_t *pSync);
 
+  __device__ void internal_direct_barrier_wg(int pe, int PE_start, int stride,
+                                             int n_pes, int64_t *pSync);
+
   __device__ void internal_atomic_barrier(int pe, int PE_start, int stride,
                                           int n_pes, int64_t *pSync);
 

--- a/src/gda/context_gda_device_coll.cpp
+++ b/src/gda/context_gda_device_coll.cpp
@@ -37,6 +37,9 @@ __device__ void GDAContext::internal_direct_barrier(int pe, int PE_start,
   if (pe == PE_start) {
     // Go through all PE offsets (except current offset = 0)
     // and wait until they all reach
+#if defined(__gfx90a__)
+    __threadfence_system();
+#endif /* __gfx90a__ */
     for (int i = 1; i < n_pes; i++) {
       wait_until(&pSync[i], ROCSHMEM_CMP_EQ, flag_val);
       pSync[i] = ROCSHMEM_SYNC_VALUE;
@@ -45,15 +48,24 @@ __device__ void GDAContext::internal_direct_barrier(int pe, int PE_start,
 
     // Announce to other PEs that all have reached
     for (int i = 1, j = PE_start + stride; i < n_pes; ++i, j += stride) {
-      put(&pSync[0], &flag_val, 1, j);
+      pSync[0] = flag_val;
+      put(&pSync[0], &pSync[0], 1, j);
+#if defined(__gfx90a__)
+      __threadfence_system();
+#endif /* __gfx90a__ */
     }
     pSync[0] = ROCSHMEM_SYNC_VALUE;
   } else {
     // Mark current PE offset as reached
     size_t pe_offset = (pe - PE_start) / stride;
-    put(&pSync[pe_offset], &flag_val, 1, PE_start);
+    pSync[pe_offset] = flag_val;
+    put(&pSync[pe_offset], &pSync[pe_offset], 1, PE_start);
+#if defined(__gfx90a__)
+    __threadfence_system();
+#endif /* __gfx90a__ */
     wait_until(&pSync[0], ROCSHMEM_CMP_EQ, flag_val);
     pSync[0] = ROCSHMEM_SYNC_VALUE;
+    pSync[pe_offset] = ROCSHMEM_SYNC_VALUE;
     __threadfence_system();
   }
 }

--- a/src/gda/context_gda_device_coll.cpp
+++ b/src/gda/context_gda_device_coll.cpp
@@ -62,20 +62,39 @@ __device__ void GDAContext::internal_direct_barrier_wg(int pe, int PE_start,
                                                        int stride, int n_pes,
                                                        int64_t *pSync) {
   int64_t flag_val{1};
-  if (pe == PE_start) {
-    if (is_thread_zero_in_block()) {
-      // Go through all PE offsets (except current offset = 0)
-      // and wait until they all reach
-      for (int i = 1; i < n_pes; i++) {
-        wait_until(&pSync[i], ROCSHMEM_CMP_EQ, flag_val);
-        pSync[i] = ROCSHMEM_SYNC_VALUE;
-      }
-      __threadfence_system();
 
-      // Announce to other PEs that all have reached
-      for (int i = 1, j = PE_start + stride; i < n_pes; ++i, j += stride) {
-        put(&pSync[0], &flag_val, 1, j);
+  if (pe == PE_start) {
+    int wf_id = get_flat_block_id() / WF_SIZE;
+    int wf_count = get_flat_block_size() / WF_SIZE;
+    bool wf_leader = 0 == get_active_lane_num();
+
+    // Go through all PE offsets (except current offset = 0)
+    // and wait until they all reach
+    if (wf_leader) {
+      for (int j = wf_id + 1; j < n_pes; j+= wf_count) {
+        wait_until(&pSync[j], ROCSHMEM_CMP_EQ, flag_val);
+        pSync[j] = ROCSHMEM_SYNC_VALUE;
       }
+    }
+
+    __syncthreads();
+
+    // Announce to other PEs that all have reached
+    for (int i = wf_id + 1, j = PE_start + stride + wf_id;
+             i < n_pes;
+             i+= wf_count, j += (wf_count * stride)) {
+      put_nbi_wave(&pSync[0], &flag_val, 1, j);
+    }
+
+    for (int i = wf_id + 1, j = PE_start + stride + wf_id;
+             i < n_pes;
+             i+= wf_count, j += (wf_count * stride)) {
+      pe_quiet(j);
+    }
+
+    __syncthreads();
+
+    if (is_thread_zero_in_block()) {
       pSync[0] = ROCSHMEM_SYNC_VALUE;
     }
   } else {

--- a/src/gda/context_gda_device_coll.cpp
+++ b/src/gda/context_gda_device_coll.cpp
@@ -37,9 +37,6 @@ __device__ void GDAContext::internal_direct_barrier(int pe, int PE_start,
   if (pe == PE_start) {
     // Go through all PE offsets (except current offset = 0)
     // and wait until they all reach
-#if defined(__gfx90a__)
-    __threadfence_system();
-#endif /* __gfx90a__ */
     for (int i = 1; i < n_pes; i++) {
       wait_until(&pSync[i], ROCSHMEM_CMP_EQ, flag_val);
       pSync[i] = ROCSHMEM_SYNC_VALUE;
@@ -48,24 +45,15 @@ __device__ void GDAContext::internal_direct_barrier(int pe, int PE_start,
 
     // Announce to other PEs that all have reached
     for (int i = 1, j = PE_start + stride; i < n_pes; ++i, j += stride) {
-      pSync[0] = flag_val;
-      put(&pSync[0], &pSync[0], 1, j);
-#if defined(__gfx90a__)
-      __threadfence_system();
-#endif /* __gfx90a__ */
+      put(&pSync[0], &flag_val, 1, j);
     }
     pSync[0] = ROCSHMEM_SYNC_VALUE;
   } else {
     // Mark current PE offset as reached
     size_t pe_offset = (pe - PE_start) / stride;
-    pSync[pe_offset] = flag_val;
-    put(&pSync[pe_offset], &pSync[pe_offset], 1, PE_start);
-#if defined(__gfx90a__)
-    __threadfence_system();
-#endif /* __gfx90a__ */
+    put(&pSync[pe_offset], &flag_val, 1, PE_start);
     wait_until(&pSync[0], ROCSHMEM_CMP_EQ, flag_val);
     pSync[0] = ROCSHMEM_SYNC_VALUE;
-    pSync[pe_offset] = ROCSHMEM_SYNC_VALUE;
     __threadfence_system();
   }
 }

--- a/src/gda/context_gda_device_coll.cpp
+++ b/src/gda/context_gda_device_coll.cpp
@@ -58,6 +58,38 @@ __device__ void GDAContext::internal_direct_barrier(int pe, int PE_start,
   }
 }
 
+__device__ void GDAContext::internal_direct_barrier_wg(int pe, int PE_start,
+                                                       int stride, int n_pes,
+                                                       int64_t *pSync) {
+  int64_t flag_val{1};
+  if (pe == PE_start) {
+    if (is_thread_zero_in_block()) {
+      // Go through all PE offsets (except current offset = 0)
+      // and wait until they all reach
+      for (int i = 1; i < n_pes; i++) {
+        wait_until(&pSync[i], ROCSHMEM_CMP_EQ, flag_val);
+        pSync[i] = ROCSHMEM_SYNC_VALUE;
+      }
+      __threadfence_system();
+
+      // Announce to other PEs that all have reached
+      for (int i = 1, j = PE_start + stride; i < n_pes; ++i, j += stride) {
+        put(&pSync[0], &flag_val, 1, j);
+      }
+      pSync[0] = ROCSHMEM_SYNC_VALUE;
+    }
+  } else {
+    if (is_thread_zero_in_block()) {
+      // Mark current PE offset as reached
+      size_t pe_offset = (pe - PE_start) / stride;
+      put(&pSync[pe_offset], &flag_val, 1, PE_start);
+      wait_until(&pSync[0], ROCSHMEM_CMP_EQ, flag_val);
+      pSync[0] = ROCSHMEM_SYNC_VALUE;
+      __threadfence_system();
+    }
+  }
+}
+
 __device__ void GDAContext::internal_atomic_barrier(int pe, int PE_start,
                                                     int stride, int n_pes,
                                                     int64_t *pSync) {
@@ -104,10 +136,10 @@ __device__ void GDAContext::internal_sync_wave(int pe, int PE_start, int stride,
 __device__ void GDAContext::internal_sync_wg(int pe, int PE_start, int stride,
                                              int PE_size, int64_t *pSync) {
   __syncthreads();
-  if (is_thread_zero_in_block()) {
-    if (PE_size < 64) {
-      internal_direct_barrier(pe, PE_start, stride, PE_size, pSync);
-    } else {
+  if (PE_size < 64) {
+    internal_direct_barrier_wg(pe, PE_start, stride, PE_size, pSync);
+  } else {
+    if (is_thread_zero_in_block()) {
       internal_atomic_barrier(pe, PE_start, stride, PE_size, pSync);
     }
   }

--- a/src/gda/context_gda_device_coll.cpp
+++ b/src/gda/context_gda_device_coll.cpp
@@ -77,7 +77,7 @@ __device__ void GDAContext::internal_direct_barrier_wg(int pe, int PE_start,
 
   if (pe == PE_start) {
     int wf_id = get_flat_block_id() / WF_SIZE;
-    int wf_count = get_flat_block_size() / WF_SIZE;
+    int wf_count = (int) ceil((double)get_flat_block_size() / (double)WF_SIZE);
     bool wf_leader = 0 == get_active_lane_num();
 
     // Go through all PE offsets (except current offset = 0)


### PR DESCRIPTION
## Motivation

- If we know an entire workgroup is calling into a barrier operation, then we can make some optimizations

## Technical Details

- Each wave:
  - Waits for its own flag
  - issues its own puts
  - quiets its own PEs

## Test Plan

- Can be tested with alltoall collective

```
mpirun -n 32   --display-map -mca pml ucx -mca osc ucx -x ROCSHMEM_MAX_NUM_CONTEXTS=1 --map-by numa --timeout 300 --hostfile /home/ytemucin/hostfile.txt
 ./tests/functional_tests/rocshmem_functional_tests -a 19 -w 1 -z 1024 -s 1024
```

## Test Result

- If we launch the barrier with a single thread, there is little to no change in pefromance
- If we use the entire workgroup (`-z 1024`) then we see up-to 2x performance improvement in alltoall_wg
