### PR TITLE
Added compile flag to disable MPI

### DIFF
--- a/include/rocshmem/rocshmem.hpp
+++ b/include/rocshmem/rocshmem.hpp
@@ -35,8 +35,10 @@
 #include "rocshmem_COLL.hpp"
 #include "rocshmem_P2P_SYNC.hpp"
 #include "rocshmem_RMA_X.hpp"
+#ifndef DISABLE_MPI
 #if defined(HAVE_EXTERNAL_MPI)
 #include <mpi.h>
+#endif
 #endif
 
 /**
@@ -60,6 +62,7 @@ constexpr char VERSION[] = "3.0.0";
 /******************************************************************************
  **************************** HOST INTERFACE **********************************
  *****************************************************************************/
+#ifndef DISABLE_MPI
 #if defined(HAVE_EXTERNAL_MPI)
 /**
  * @brief Initialize the rocSHMEM runtime and underlying transport layer.
@@ -68,6 +71,7 @@ constexpr char VERSION[] = "3.0.0";
  *                      If MPI_COMM_NULL, rocSHMEM will be using MPI_COMM_WORLD
  */
 [[deprecated]] __host__ void rocshmem_init(MPI_Comm comm);
+#endif
 #endif
 
 /**
@@ -100,6 +104,7 @@ __host__ void * rocshmem_get_device_ctx();
  */
 __host__ void *rocshmem_ptr(void *dest, int pe);
 
+#ifndef DISABLE_MPI
 #if defined(HAVE_EXTERNAL_MPI)
 /**
  * @brief Initialize the rocSHMEM runtime and underlying transport layer
@@ -117,6 +122,7 @@ __host__ void *rocshmem_ptr(void *dest, int pe);
  */
 [[deprecated]] __host__ int rocshmem_init_thread(int requested, int *provided,
                                                  MPI_Comm comm);
+#endif
 #endif
 
 /**


### PR DESCRIPTION
## Motivation

This PR adds compile flags to disable MPI when DeepEP is built with the `--disable-mpi` flag. The changes in this PR can allow DeepEP's modified build command to work.
`python3 setup.py --variant rocm --disable-mpi build develop`

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
