### PR TITLE
Remove LOAD/STORE macros, explode store_asm into store_asmN where N=2..8

### DIFF
--- a/src/assembly.hpp
+++ b/src/assembly.hpp
@@ -182,49 +182,61 @@ __device__ __forceinline__ void __roc_flush() {
 #endif
 }
 
+__device__ __forceinline__ void store_asm2(uint16_t& val, uint16_t* dst) {
+#if defined(__gfx906__)
+#endif
+#if defined(__gfx908__)
+#endif
+#if defined(__gfx90a__) || defined (__gfx1100__)
+  asm volatile("flat_store_short %0 %1 glc slc" : : "v"(dst), "v"(val));
+#endif
+#if defined(__gfx942__) || defined(__gfx950__)
+  asm volatile("flat_store_short %0 %1 sc0 sc1" : : "v"(dst), "v"(val));
+#endif
+}
+
+__device__ __forceinline__ void store_asm4(uint32_t& val, uint32_t* dst) {
+#if defined(__gfx906__)
+#endif
+#if defined(__gfx908__)
+#endif
+#if defined(__gfx90a__) || defined (__gfx1100__)
+      asm volatile("flat_store_dword %0 %1 glc slc" : : "v"(dst), "v"(val));
+#endif
+#if defined(__gfx942__) || defined(__gfx950__)
+      asm volatile("flat_store_dword %0 %1 sc0 sc1" : : "v"(dst), "v"(val));
+#endif
+}
+
+__device__ __forceinline__ void store_asm8(uint64_t& val, uint64_t* dst) {
+#if defined(__gfx906__)
+#endif
+#if defined(__gfx908__)
+#endif
+#if defined(__gfx90a__) || defined (__gfx1100__)
+      asm volatile("flat_store_dwordx2 %0 %1 glc slc" : : "v"(dst), "v"(val));
+#endif
+#if defined(__gfx942__) || defined(__gfx950__)
+      asm volatile("flat_store_dwordx2 %0 %1 sc0 sc1" : : "v"(dst), "v"(val));
+#endif
+}
+
 __device__ __forceinline__ void store_asm(uint8_t* val, uint8_t* dst,
                                           int size) {
   switch (size) {
     case 2: {
-      int16_t val16{*(reinterpret_cast<int16_t*>(val))};
-#if defined(__gfx906__)
-#endif
-#if defined(__gfx908__)
-#endif
-#if defined(__gfx90a__) || defined (__gfx1100__)
-      asm volatile("flat_store_short %0 %1 glc slc" : : "v"(dst), "v"(val16));
-#endif
-#if defined(__gfx942__) || defined(__gfx950__)
-      asm volatile("flat_store_short %0 %1 sc0 sc1" : : "v"(dst), "v"(val16));
-#endif
+      uint16_t val16{*(reinterpret_cast<uint16_t*>(val))};
+      store_asm2(val16, (uint16_t*)dst);
       break;
     }
     case 4: {
-      int32_t val32{*(reinterpret_cast<int32_t*>(val))};
-#if defined(__gfx906__)
-#endif
-#if defined(__gfx908__)
-#endif
-#if defined(__gfx90a__) || defined (__gfx1100__)
-      asm volatile("flat_store_dword %0 %1 glc slc" : : "v"(dst), "v"(val32));
-#endif
-#if defined(__gfx942__) || defined(__gfx950__)
-      asm volatile("flat_store_dword %0 %1 sc0 sc1" : : "v"(dst), "v"(val32));
-#endif
+      uint32_t val32{*(reinterpret_cast<uint32_t*>(val))};
+      store_asm4(val32, (uint32_t*)dst);
       break;
     }
     case 8: {
-      int64_t val64{*(reinterpret_cast<int64_t*>(val))};
-#if defined(__gfx906__)
-#endif
-#if defined(__gfx908__)
-#endif
-#if defined(__gfx90a__) || defined (__gfx1100__)
-      asm volatile("flat_store_dwordx2 %0 %1 glc slc" : : "v"(dst), "v"(val64));
-#endif
-#if defined(__gfx942__) || defined(__gfx950__)
-      asm volatile("flat_store_dwordx2 %0 %1 sc0 sc1" : : "v"(dst), "v"(val64));
-#endif
+      uint64_t val64{*(reinterpret_cast<uint64_t*>(val))};
+      store_asm8(val64, (uint64_t*)dst);
       break;
     }
     default:
@@ -234,4 +246,4 @@ __device__ __forceinline__ void store_asm(uint8_t* val, uint8_t* dst,
 
 }  // namespace rocshmem
 
-#endif  // LIBRARY_SRC_ASSEMBLY_HPP_
+#endif  // 

--- a/src/hdp_policy.hpp
+++ b/src/hdp_policy.hpp
@@ -64,7 +64,7 @@ class HdpHostSideFlushRocmPolicy {
    * @param hdp_ptr A pointer to use as the HDP flush ptr
    */
   __device__ static void hdp_flush(unsigned int* hdp_ptr) {
-    STORE(hdp_ptr, static_cast<unsigned int>(hdp_poll_flag::FLUSH));
+    __atomic_store_n(hdp_ptr, static_cast<unsigned int>(hdp_poll_flag::FLUSH), __ATOMIC_SEQ_CST);
   }
 
   /**
@@ -141,7 +141,7 @@ class HdpDeviceSideFlushRocmPolicy {
    * @brief Flush the HDP by setting the flush control signal
    */
   __host__ __device__ void hdp_flush() {
-    STORE(hdp_flush_ptr_, static_cast<unsigned int>(HDP_FLUSH_VAL));
+    __atomic_store_n(hdp_flush_ptr_, static_cast<unsigned int>(HDP_FLUSH_VAL), __ATOMIC_SEQ_CST);
   }
   __device__ void flushCoherency() { hdp_flush(); }
 

--- a/src/util.hpp
+++ b/src/util.hpp
@@ -382,9 +382,6 @@ __device__ void gpu_dprintf(const char* fmt, const Args&... args) {
   }
 }
 
-#define LOAD(VAR) __atomic_load_n((VAR), __ATOMIC_SEQ_CST)
-#define STORE(DST, SRC) __atomic_store_n((DST), (SRC), __ATOMIC_SEQ_CST)
-
 __device__ __forceinline__ void memcpy_lane(void* dst, void* src, size_t size) {
   uint8_t* dst_bytes{static_cast<uint8_t*>(dst)};
   uint8_t* src_bytes{static_cast<uint8_t*>(src)};


### PR DESCRIPTION
## Motivation

1. Remove unused code
2. Enable removing switch from critical path in memcpy_lane/wave/wg?

## Technical Details

Remove LOAD-STORE macros and replace usage of STORE macro with its definition in HDP policy
Split `store_asm` into its component functions `store_asm{2,4,8}` so that we can call the right one from a flattened memcpy_lane (separate pr)

## Test Plan

Run IPC testers