### PR TITLE
Fix rocshmem_ptr definition signature

### DIFF
--- a/src/rocshmem.cpp
+++ b/src/rocshmem.cpp
@@ -418,7 +418,7 @@ static BackendType select_backend_type() {
   backend->heap.free(ptr);
 }
 
-__host__ void * rocshmem_ptr(void * dest, int pe){
+__host__ void * rocshmem_ptr(const void * dest, int pe){
 
   Context *ctx = reinterpret_cast<Context *>(ROCSHMEM_HOST_CTX_DEFAULT.ctx_opaque);
 


### PR DESCRIPTION
Makes the signature of the definition match the declaration in rocshmem.hpp.

## Motivation

Fixes an error that came up while updating rocshmem in Triton-distributed.

## Technical Details

Building Triton-distributed with a newer version of rocshmem and the GDA backend enabled led to a link failure because rocshmem.hpp specifies a different call signature than the definition.

## Test Plan

Triton-distributed test `test_ag_gemm_intra_node.py` passes with `ROCSHMEM_BACKEND=GDA` using patch https://github.com/erieaton-amd/Triton-distributed/tree/gda

## Test Result

✅ Triton and Torch match