### PR TITLE
Add backend type query method, use it to disable 32bit amo testers on gda

### DIFF
--- a/include/rocshmem/rocshmem_common.hpp
+++ b/include/rocshmem/rocshmem_common.hpp
@@ -138,6 +138,13 @@ extern __constant__ rocshmem_ctx_t ROCSHMEM_CTX_INVALID;
  */
 void set_internal_ctx(rocshmem_ctx_t *ctx);
 
+/**
+ * Used internally to query the loaded backend
+ */
+//TODO: this should remain internal?
+enum class BackendType { GDA_BACKEND, RO_BACKEND, IPC_BACKEND };
+BackendType get_backend_type();
+
 typedef uint64_t *rocshmem_team_t;
 extern rocshmem_team_t ROCSHMEM_TEAM_WORLD;
 

--- a/scripts/functional_tests/driver.sh
+++ b/scripts/functional_tests/driver.sh
@@ -628,6 +628,11 @@ TestGDA() {
   # This test requires more contexts than workgroups
   export ROCSHMEM_MAX_NUM_CONTEXTS=1024
   ExecTest  "teamctxinfra"     2       1            1
+  ExecTest  "teamctxsingleinfra"  2       1            1
+  ExecTest  "teamctxblockinfra"   4       1            1
+  ExecTest  "teamctxblockinfra"   5       1            1
+  ExecTest  "teamctxoddeveninfra" 4       1            1
+  ExecTest  "teamctxoddeveninfra" 5       1            1
   unset ROCSHMEM_MAX_NUM_CONTEXTS
 }
 

--- a/scripts/functional_tests/driver.sh
+++ b/scripts/functional_tests/driver.sh
@@ -556,48 +556,44 @@ TestGDA() {
   ##############################################################################
   #       | Name             | Ranks | Workgroups | Threads | Max Message Size #
   ##############################################################################
-#  ExecTest  "amo_fetch"        2       1            1
-#  ExecTest  "amo_fetch"        2       1            1024
-#  ExecTest  "amo_fetch"        2       8            1
-#  ExecTest  "amo_fetch"        2       32           128
+  ExecTest  "amo_fetch"        2       1            1
+  ExecTest  "amo_fetch"        2       1            1024
+  ExecTest  "amo_fetch"        2       8            1
+  ExecTest  "amo_fetch"        2       32           128
 
-#  ExecTest  "amo_set"          2       1            1
-#  ExecTest  "amo_set"          2       8            1
-#  ExecTest  "amo_set"          2       32           1
+  ExecTest  "amo_set"          2       1            1
+  ExecTest  "amo_set"          2       8            1
+  ExecTest  "amo_set"          2       32           1
 
-#  ExecTest  "amo_fcswap"       2       1            1
-#  ExecTest  "amo_fcswap"       2       32           1
-#  ExecTest  "amo_fcswap"       2       8            1
+  ExecTest  "amo_fcswap"       2       1            1
+  ExecTest  "amo_fcswap"       2       32           1
+  ExecTest  "amo_fcswap"       2       8            1
 
-#This works but tester requires 32bit amos to be implemented
-#  ExecTest  "amo_finc"         2       1            1
-#  ExecTest  "amo_finc"         2       1            1024
-#  ExecTest  "amo_finc"         2       8            1
-#  ExecTest  "amo_finc"         2       32           128
+  ExecTest  "amo_finc"         2       1            1
+  ExecTest  "amo_finc"         2       1            1024
+  ExecTest  "amo_finc"         2       8            1
+  ExecTest  "amo_finc"         2       32           128
 
-#This works but tester requires get
-#  ExecTest  "amo_inc"          2       1            1
-#  ExecTest  "amo_inc"          2       1            1024
-#  ExecTest  "amo_inc"          2       8            1
-#  ExecTest  "amo_inc"          2       32           128
+  ExecTest  "amo_inc"          2       1            1
+  ExecTest  "amo_inc"          2       1            1024
+  ExecTest  "amo_inc"          2       8            1
+  ExecTest  "amo_inc"          2       32           128
 
-#This works but tester requires 32bit amos to be implemented
-#  ExecTest  "amo_fadd"         2       1            1
-#  ExecTest  "amo_fadd"         2       1            1024
-#  ExecTest  "amo_fadd"         2       8            1
-#  ExecTest  "amo_fadd"         2       32           128
+  ExecTest  "amo_fadd"         2       1            1
+  ExecTest  "amo_fadd"         2       1            1024
+  ExecTest  "amo_fadd"         2       8            1
+  ExecTest  "amo_fadd"         2       32           128
 
-#This works but tester requires get
-#  ExecTest  "amo_add"          2       1            1
-#  ExecTest  "amo_add"          2       1            1024
-#  ExecTest  "amo_add"          2       8            1
-#  ExecTest  "amo_add"          2       32           128
+  ExecTest  "amo_add"          2       1            1
+  ExecTest  "amo_add"          2       1            1024
+  ExecTest  "amo_add"          2       8            1
+  ExecTest  "amo_add"          2       32           128
 
-#  ExecTest  "amo_fetchand"     2       1            1
+  ExecTest  "amo_fetchand"     2       1            1
 
-#  ExecTest  "amo_and"          2       1            1
+  ExecTest  "amo_and"          2       1            1
 
-#  ExecTest  "amo_xor"          2       1            1
+  ExecTest  "amo_xor"          2       1            1
 
 #TestColl() {
   ##############################################################################
@@ -609,13 +605,14 @@ TestGDA() {
   ExecTest  "teamsync"         2       1            1
   ExecTest  "syncall"          2       1            1
 
-#  ExecTest  "alltoall"         2       1            1         512
+  ExecTest  "alltoall"         2       1            1         512
 
-#  ExecTest  "teambroadcast"    2       1            1         32768
+  ExecTest  "teambroadcast"    2       1            1         32768
 
-#  ExecTest  "fcollect"         2       1            1         512
-#  ExecTest  "fcollect"         2       1            1         32768
+  ExecTest  "fcollect"         2       1            1         512
+  ExecTest  "fcollect"         2       1            1         32768
 
+# deadlock on gda, size 8KB
 #  ExecTest  "teamreduction"    2       1            1         32768
 
 #TestOther() {

--- a/src/backend_bc.hpp
+++ b/src/backend_bc.hpp
@@ -276,6 +276,8 @@ class Backend {
    */
   TeamTracker team_tracker{};
 
+  BackendType get_backend_type() { return type; }
+
  protected:
   /**
    * @brief Required to support static inheritance for device calls.

--- a/src/backend_type.hpp
+++ b/src/backend_type.hpp
@@ -46,7 +46,7 @@ namespace rocshmem {
  * @note Derived classes which use Backend as a base class must add
  * themselves to this enum class to support static polymorphism.
  */
-enum class BackendType { GDA_BACKEND, RO_BACKEND, IPC_BACKEND };
+//enum class BackendType { GDA_BACKEND, RO_BACKEND, IPC_BACKEND };
 
 /**
  * @brief Helper macro for some dispatch calls

--- a/src/rocshmem.cpp
+++ b/src/rocshmem.cpp
@@ -81,6 +81,8 @@ rocshmem_ctx_t ROCSHMEM_HOST_CTX_DEFAULT;
  * Begin Host Code
  **/
 
+BackendType get_backend_type() { return backend->get_backend_type(); }
+
 #if defined(USE_GDA) && defined(USE_RO) && defined(USE_IPC)
 static BackendType select_backend_type() {
   BackendType type;

--- a/tests/functional_tests/tester.cpp
+++ b/tests/functional_tests/tester.cpp
@@ -56,6 +56,9 @@
 #include "wavefront_primitives.hpp"
 #include "workgroup_primitives.hpp"
 
+#include "backend_bc.hpp"
+extern Backend* backend;
+
 Tester::Tester(TesterArguments args) : args(args) {
   _type = (TestType)args.algorithm;
   _shmem_context = args.shmem_context;
@@ -102,6 +105,7 @@ std::vector<Tester*> Tester::create(TesterArguments args) {
 
   if (rank == 0) std::cout << "### Creating Test: ";
 
+  BackendType backend_type = get_backend_type();
   TestType type = (TestType)args.algorithm;
 
   switch (type) {
@@ -245,85 +249,99 @@ std::vector<Tester*> Tester::create(TesterArguments args) {
       if (rank == 0) std::cout << "AMO Fetch_Add ###" << std::endl;
       testers.push_back(new AMOStandardTester<long long>(args));
       testers.push_back(new AMOStandardTester<long>(args));
-      testers.push_back(new AMOStandardTester<int>(args));
+      if (BackendType::GDA_BACKEND != backend_type) // not implemented for GDA
+        testers.push_back(new AMOStandardTester<int>(args));
       return testers;
     case AMO_FIncTestType:
       if (rank == 0) std::cout << "AMO Fetch_Inc ###" << std::endl;
       testers.push_back(new AMOStandardTester<long long>(args));
       testers.push_back(new AMOStandardTester<long>(args));
-      testers.push_back(new AMOStandardTester<int>(args));
+      if (BackendType::GDA_BACKEND != backend_type) // not implemented for GDA
+        testers.push_back(new AMOStandardTester<int>(args));
       return testers;
     case AMO_FetchTestType:
       if (rank == 0) std::cout << "AMO Fetch ###" << std::endl;
       testers.push_back(new AMOExtendedTester<long long>(args));
       testers.push_back(new AMOExtendedTester<long>(args));
-      testers.push_back(new AMOExtendedTester<int>(args));
+      if (BackendType::GDA_BACKEND != backend_type) // not implemented for GDA
+        testers.push_back(new AMOExtendedTester<int>(args));
       return testers;
     case AMO_FCswapTestType:
       if (rank == 0) std::cout << "AMO Fetch_CSWAP ###" << std::endl;
       testers.push_back(new AMOStandardTester<long long>(args));
       testers.push_back(new AMOStandardTester<long>(args));
-      testers.push_back(new AMOStandardTester<int>(args));
+      if (BackendType::GDA_BACKEND != backend_type) // not implemented for GDA
+        testers.push_back(new AMOStandardTester<int>(args));
       return testers;
     case AMO_AddTestType:
       if (rank == 0) std::cout << "AMO Add ###" << std::endl;
       testers.push_back(new AMOStandardTester<long long>(args));
       testers.push_back(new AMOStandardTester<long>(args));
-      testers.push_back(new AMOStandardTester<int>(args));
+      if (BackendType::GDA_BACKEND != backend_type) // not implemented for GDA
+        testers.push_back(new AMOStandardTester<int>(args));
       return testers;
     case AMO_SetTestType:
       if (rank == 0) std::cout << "AMO Set ###" << std::endl;
       testers.push_back(new AMOExtendedTester<long long>(args));
       testers.push_back(new AMOExtendedTester<long>(args));
-      testers.push_back(new AMOExtendedTester<int>(args));
+      if (BackendType::GDA_BACKEND != backend_type) // not implemented for GDA
+        testers.push_back(new AMOExtendedTester<int>(args));
       return testers;
     case AMO_SwapTestType:
       if (rank == 0) std::cout << "AMO Swap ###" << std::endl;
       testers.push_back(new AMOExtendedTester<long long>(args));
       testers.push_back(new AMOExtendedTester<long>(args));
-      testers.push_back(new AMOExtendedTester<int>(args));
+      if (BackendType::GDA_BACKEND != backend_type) // not implemented for GDA
+        testers.push_back(new AMOExtendedTester<int>(args));
       return testers;
     case AMO_FetchAndTestType:
       if (rank == 0) std::cout << "AMO Fetch And ###" << std::endl;
       testers.push_back(new AMOBitwiseTester<unsigned long long>(args));
       testers.push_back(new AMOBitwiseTester<unsigned long>(args));
-      testers.push_back(new AMOBitwiseTester<unsigned int>(args));
+      if (BackendType::GDA_BACKEND != backend_type) // not implemented for GDA
+        testers.push_back(new AMOBitwiseTester<unsigned int>(args));
       return testers;
     case AMO_AndTestType:
       if (rank == 0) std::cout << "AMO And ###" << std::endl;
       testers.push_back(new AMOBitwiseTester<unsigned long long>(args));
       testers.push_back(new AMOBitwiseTester<unsigned long>(args));
-      testers.push_back(new AMOBitwiseTester<unsigned int>(args));
+      if (BackendType::GDA_BACKEND != backend_type) // not implemented for GDA
+        testers.push_back(new AMOBitwiseTester<unsigned int>(args));
       return testers;
     case AMO_FetchOrTestType:
       if (rank == 0) std::cout << "AMO Fetch Or ###" << std::endl;
       testers.push_back(new AMOBitwiseTester<unsigned long long>(args));
       testers.push_back(new AMOBitwiseTester<unsigned long>(args));
-      testers.push_back(new AMOBitwiseTester<unsigned int>(args));
+      if (BackendType::GDA_BACKEND != backend_type) // not implemented for GDA
+        testers.push_back(new AMOBitwiseTester<unsigned int>(args));
       return testers;
     case AMO_OrTestType:
       if (rank == 0) std::cout << "AMO Or ###" << std::endl;
       testers.push_back(new AMOBitwiseTester<unsigned long long>(args));
       testers.push_back(new AMOBitwiseTester<unsigned long>(args));
-      testers.push_back(new AMOBitwiseTester<unsigned int>(args));
+      if (BackendType::GDA_BACKEND != backend_type) // not implemented for GDA
+        testers.push_back(new AMOBitwiseTester<unsigned int>(args));
       return testers;
     case AMO_FetchXorTestType:
       if (rank == 0) std::cout << "AMO Fetch Xor ###" << std::endl;
       testers.push_back(new AMOBitwiseTester<unsigned long long>(args));
       testers.push_back(new AMOBitwiseTester<unsigned long>(args));
-      testers.push_back(new AMOBitwiseTester<unsigned int>(args));
+      if (BackendType::GDA_BACKEND != backend_type) // not implemented for GDA
+        testers.push_back(new AMOBitwiseTester<unsigned int>(args));
       return testers;
     case AMO_XorTestType:
       if (rank == 0) std::cout << "AMO Xor ###" << std::endl;
       testers.push_back(new AMOBitwiseTester<unsigned long long>(args));
       testers.push_back(new AMOBitwiseTester<unsigned long>(args));
-      testers.push_back(new AMOBitwiseTester<unsigned int>(args));
+      if (BackendType::GDA_BACKEND != backend_type) // not implemented for GDA
+        testers.push_back(new AMOBitwiseTester<unsigned int>(args));
       return testers;
     case AMO_IncTestType:
       if (rank == 0) std::cout << "AMO Inc ###" << std::endl;
       testers.push_back(new AMOStandardTester<long long>(args));
       testers.push_back(new AMOStandardTester<long>(args));
-      testers.push_back(new AMOStandardTester<int>(args));
+      if (BackendType::GDA_BACKEND != backend_type) // not implemented for GDA
+        testers.push_back(new AMOStandardTester<int>(args));
       return testers;
     case PingPongTestType:
       if (rank == 0) std::cout << "PingPong ###" << std::endl;


### PR DESCRIPTION
## Motivation

We cannot run amo testers because the 32 bit gda amos are not implemented. This PR detect what is the loaded backend and configure the tester to run only implemented configurations

## Technical Details

Added a get_backend_type method to query what is the type of the runtime selected backend, use that method to configure in tester.cpp.

## Test Plan

Executed GDA testsuite on Banff cx7 GDA 2-nodes, RO and IPC-1 node

