### PR TITLE
python venv madness round 2: use ensurepip if installed

### DIFF
--- a/scripts/install_dependencies.sh
+++ b/scripts/install_dependencies.sh
@@ -72,7 +72,7 @@ git clone --recursive $_OMPI_REPO
 cd ompi
 git checkout $_OMPI_COMMIT_HASH
 git submodule update --init --recursive
-python3 -m venv --system-site-packages --without-pip venv
+python3 -m ensurepip && python3 -m venv venv || python3 -m venv --system-site-packages --without-pip venv
 . venv/bin/activate
 python3 -m pip install -r docs/requirements.txt
 ./autogen.pl


### PR DESCRIPTION
## Motivation

When creating a python venv during the install_dependencies script, we try to use ensurepip if it is installed, as it deals better with cases where multiple venvs are active simultaneously. (as seen in CI buildbot)

## Technical Details

try to use ensurepip, failover to python -m venv --without-pip only if no other option

## Test Plan
Ran on Ubuntu 22, Ubuntu 24, ci-docker

