### PR TITLE
disable memory unit tests

### DIFF
--- a/scripts/unit_tests/driver.sh
+++ b/scripts/unit_tests/driver.sh
@@ -76,7 +76,7 @@ case $mode in
     all)
         test_with_two_pes="IPCImplSimpleCoarseTestFixture/*:IPCImplSimpleFineTestFixture/*:IPCImplTiledFineTestFixture/*:DegenerateTiledFine.*"
         run_mpirun 4 "-$test_with_two_pes"
-        run_mpirun 2 "$test_with_two_pes"
+        #run_mpirun 2 "$test_with_two_pes"
         ;;
     custom)
         # Check if ranks is a positive integer


### PR DESCRIPTION
##What

disable fine-grain and coarse-grain memory testst until a fix is available in ROCm 7.1 and/or our CI image. 

## Motivation

Otherwise we might miss other errors due to constant CI failures.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
