### PR TITLE
gda: fix getmem_nbi_wg source and dest

### DIFF
--- a/src/gda/context_gda_device.cpp
+++ b/src/gda/context_gda_device.cpp
@@ -214,7 +214,7 @@ __device__ void GDAContext::getmem_nbi_wg(void *dest, const void *source,
   }
   uint64_t L_offset = const_cast<char *>(src_typed) - base_heap[my_pe];
   if (is_wave_zero_in_block()) {
-    qps[pe].get_nbi(base_heap[pe] + L_offset, source, nelems, pe, QueuePair::WAVE);
+    qps[pe].get_nbi(dest, base_heap[pe] + L_offset, nelems, pe, QueuePair::WAVE);
   }
 }
 


### PR DESCRIPTION
A copy paste mistake in a previous commit caused source and dest to be reversed.  Correct the source and dest params.

Fixes: 6de67d5d7c270d9867bafed3897f0d771fd08cd9

## Motivation

Fix a bug introduced by a previous commit.

## Technical Details

Previous commit caused source and dest to be reversed in GDAContext::getmem_nbi_wg.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
- [x] Verficiation with rocshmem functional tests:
  - [x] wggetnbi_n2_w1_z64_1048576B
  - [x] wggetnbi_n2_w2_z64_1048576B
  - [x] wggetnbi_n2_w16_z64_8B