### PR TITLE
replace MPI function call.

### DIFF
--- a/include/rocshmem/rocshmem_mpi.hpp
+++ b/include/rocshmem/rocshmem_mpi.hpp
@@ -63,6 +63,8 @@ typedef struct ompi_status_public_t MPI_Status;
 #define MPI_IN_PLACE (void*)1
 #define MPI_MODE_NOCHECK 1
 #define MPI_COMM_TYPE_SHARED 0
+#define MPI_ANY_SOURCE -1
+#define MPI_STATUSES_IGNORE (static_cast<MPI_Status*>(0))
 
 #define MPI_Aint_diff(addr1, addr2) ((MPI_Aint) ((char *) (addr1) - (char *) (addr2)))
 

--- a/src/reverse_offload/ro_team_proxy.hpp
+++ b/src/reverse_offload/ro_team_proxy.hpp
@@ -44,7 +44,7 @@ class ROTeamProxy {
               size_t num_elems = 1)
     : my_pe_(pe), team_size_(npes), proxy_{num_elems} {
 
-    MPI_Comm_dup(comm, &team_world_comm_);
+    mpilib_ftable_.Comm_dup(comm, &team_world_comm_);
 
     new (proxy_.get()) ROTeam(backend, wrt_parent_.get(), wrt_world_.get(),
                               team_size_, my_pe_, team_world_comm_);
@@ -65,7 +65,7 @@ class ROTeamProxy {
   ~ROTeamProxy() {
     proxy_.get()->~ROTeam();
 
-    MPI_Comm_free(&team_world_comm_);
+    mpilib_ftable_.Comm_free(&team_world_comm_);
   }
 
   /*
@@ -77,7 +77,7 @@ class ROTeamProxy {
   /**
    * @brief Holds duplicated mpi world communicator.
    */
-  MPI_Comm team_world_comm_{MPI_COMM_NULL};
+  MPI_Comm team_world_comm_;
 
   /**
    * @brief Used by TeamInfo members and the constructor to build ROTeam.


### PR DESCRIPTION
## Motivation
we missed one location to replace the MPI function call by its counterpart from the mpi_ftable_ structure.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
