### PR TITLE
Feat/multi qps per endpoint

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -215,6 +215,9 @@ if (NOT BUILD_TESTS_ONLY)
       -fgpu-rdc
   )
 
+  # Enable warp sync builtins
+  target_compile_definitions(${PROJECT_NAME} PRIVATE HIP_ENABLE_WARP_SYNC_BUILTINS=1)
+
   #############################################################################
   # INSTALL
   #############################################################################

--- a/src/envvar.cpp
+++ b/src/envvar.cpp
@@ -68,6 +68,8 @@ namespace envvar {
     const var<std::string> provider("PROVIDER", "");
     const var<bool> alternate_qp_ports("ALTERNATE_QP_PORTS", "", true);
     const var<uint8_t> traffic_class("TRAFFIC_CLASS", "", 0);
+    const var<size_t> num_qps_per_pe_default_ctx("NUM_QPS_PER_PE_DEFAULT_CTX", "", 2);
+    const var<size_t> num_qps_per_pe_usr_ctx("NUM_QPS_PER_PE_USR_CTX", "", 2);
   }  // namespace gda
 
   namespace _detail {

--- a/src/envvar.hpp
+++ b/src/envvar.hpp
@@ -451,6 +451,10 @@ namespace envvar {
     extern const var<std::string> provider;
     extern const var<bool> alternate_qp_ports;
     extern const var<uint8_t> traffic_class;
+    // Number of QPs to create per PE for the default context
+    extern const var<size_t> num_qps_per_pe_default_ctx;
+    // Number of QPs to create per PE for each user context
+    extern const var<size_t> num_qps_per_pe_usr_ctx;
   }  // namespace gda
 }  // namespace envvar
 }  // namespace rocshmem

--- a/src/gda/backend_gda.cpp
+++ b/src/gda/backend_gda.cpp
@@ -77,6 +77,14 @@ void GDABackend::init() {
 
   select_nic();
 
+  // Determine number of QPs to create per PE
+  num_qps_per_pe = envvar::gda::num_qps_per_pe_default_ctx.get_value() +
+                   envvar::gda::num_qps_per_pe_usr_ctx.get_value() *
+                   envvar::max_num_contexts;
+
+  // Total number of QPs created
+  num_qps = num_qps_per_pe * num_pes;
+
   //TODO setup_host_interface();
   /* Initialize the host interface */
   if (MPI_COMM_NULL != backend_comm)
@@ -743,7 +751,7 @@ void GDABackend::exchange_qp_dest_info() {
     dest_info[i].gid = gid;
   }
 
-  for (size_t i = 0; i < envvar::max_num_contexts + 1; i++) {
+  for (size_t i = 0; i < num_qps_per_pe; i++) {
     if (backend_comm != MPI_COMM_NULL) {
       mpilib_ftable_.Alltoall(MPI_IN_PLACE, sizeof(dest_info_t), MPI_CHAR, dest_info.data() + i * num_pes, sizeof(dest_info_t), MPI_CHAR, backend_comm);
     } else {
@@ -794,7 +802,7 @@ void GDABackend::setup_gpu_qps() {
   size_t qp_objs_count;
   size_t qp_objs_mem_size;
 
-  qp_objs_count    = (envvar::max_num_contexts + 1) * num_pes;
+  qp_objs_count    = num_qps;
   qp_objs_mem_size = sizeof(QueuePair) * qp_objs_count;
 
   CHECK_HIP(hipMalloc(&gpu_qps, qp_objs_mem_size));
@@ -813,7 +821,7 @@ void GDABackend::setup_gpu_qps() {
 void GDABackend::cleanup_gpu_qps() {
   size_t qp_objs_count;
 
-  qp_objs_count = (envvar::max_num_contexts + 1) * num_pes;
+  qp_objs_count = num_qps;
 
   for (size_t i = 0; i < qp_objs_count; i++) {
     host_qps[i].~QueuePair();
@@ -1031,7 +1039,6 @@ void GDABackend::modify_qps_rtr_to_rts() {
 
 void GDABackend::create_queues() {
   int ncqes;
-  size_t resize_length;
 
   if (gda_provider == GDAProvider::IONIC) {
     ncqes = envvar::sq_size << 1;
@@ -1039,15 +1046,13 @@ void GDABackend::create_queues() {
     ncqes = envvar::sq_size;
   }
 
-  resize_length = (envvar::max_num_contexts + 1) * num_pes;
+  dest_info.resize(num_qps);
+  cqs.resize(num_qps);
+  qps.resize(num_qps);
 
-  dest_info.resize(resize_length);
-  cqs.resize(resize_length);
-  qps.resize(resize_length);
-
-  bnxt_scqs.resize(resize_length);
-  bnxt_rcqs.resize(resize_length);
-  bnxt_qps.resize(resize_length);
+  bnxt_scqs.resize(num_qps);
+  bnxt_rcqs.resize(num_qps);
+  bnxt_qps.resize(num_qps);
 
   if (gda_provider == GDAProvider::BNXT) {
     bnxt_create_cqs(ncqes);
@@ -1092,7 +1097,7 @@ void GDABackend::alternate_qp_ports() {
      */
 
     /* Re-Map each context */
-    for (size_t i = 1; i < (envvar::max_num_contexts + 1); i += 2) {
+    for (size_t i = 1; i < num_qps_per_pe; i += 2) {
       for (size_t p = 0; p < num_pes; p += 2) {
         cur_qp_idx = (i * num_pes) + p;
         new_qp_idx = cur_qp_idx + 1;

--- a/src/gda/backend_gda.hpp
+++ b/src/gda/backend_gda.hpp
@@ -107,6 +107,19 @@ class GDABackend : public Backend {
   uint64_t *gpu_db_sq = nullptr;
   /* GDA_IONIC END */
 
+  /**
+   * Determine number of QPs to create per PE =
+   * ROCSHMEM_GDA_NUM_QPS_PER_PE_DEFAULT_CTX +
+   * ROCSHMEM_GDA_NUM_QPS_PER_PE_USR_CTX * ROCSHMEM_MAX_NUM_CONTEXTS
+   */
+  size_t num_qps_per_pe {1};
+
+  /**
+   * Total number of QPs created =
+   * num_qps_per_pe * num_pes;
+   */
+  uint32_t num_qps {1};
+
  /**
    * @brief Choose nic device according to locality/user preferences
    */

--- a/src/gda/context_gda_device.cpp
+++ b/src/gda/context_gda_device.cpp
@@ -128,6 +128,12 @@ __device__ uint32_t GDAContext::get_qp_index(int pe) {
   return qp_index;
 }
 
+__device__ char* GDAContext::get_remote_ptr(const void* addr, int pe) {
+  const char* addr_ = reinterpret_cast<const char*>(addr);
+  uint64_t L_offset = addr_ - base_heap[my_pe];
+  return base_heap[pe] + L_offset;
+}
+
 __device__ void GDAContext::ctx_create() {
 }
 
@@ -142,9 +148,8 @@ __device__ void GDAContext::putmem(void *dest, const void *source, size_t nelems
     ipcImpl_.ipcCopy(ipcImpl_.ipc_bases[local_pe] + L_offset, const_cast<void *>(source), nelems);
     return;
   }
-  uint64_t L_offset = reinterpret_cast<char*>(dest) - base_heap[my_pe];
   int qp_index = get_qp_index(pe);
-  qps[qp_index].put_nbi(base_heap[pe] + L_offset, source, nelems, pe);
+  qps[qp_index].put_nbi(get_remote_ptr(dest, pe), source, nelems, pe);
   qps[qp_index].quiet();
 }
 
@@ -157,9 +162,8 @@ __device__ void GDAContext::getmem(void *dest, const void *source, size_t nelems
     ipcImpl_.ipcCopy(dest, ipcImpl_.ipc_bases[local_pe] + L_offset, nelems);
     return;
   }
-  uint64_t L_offset = const_cast<char *>(src_typed) - base_heap[my_pe];
   int qp_index = get_qp_index(pe);
-  qps[qp_index].get_nbi(dest, base_heap[pe] + L_offset, nelems, pe);
+  qps[qp_index].get_nbi(dest, get_remote_ptr(source, pe), nelems, pe);
   qps[qp_index].quiet();
 }
 
@@ -171,8 +175,7 @@ __device__ void GDAContext::putmem_nbi(void *dest, const void *source,
     ipcImpl_.ipcCopy(ipcImpl_.ipc_bases[local_pe] + L_offset, const_cast<void *>(source), nelems);
     return;
   }
-  uint64_t L_offset = reinterpret_cast<char*>(dest) - base_heap[my_pe];
-  qps[get_qp_index(pe)].put_nbi(base_heap[pe] + L_offset, source, nelems, pe);
+  qps[get_qp_index(pe)].put_nbi(get_remote_ptr(dest, pe), source, nelems, pe);
 }
 
 __device__ void GDAContext::getmem_nbi(void *dest, const void *source,
@@ -184,8 +187,7 @@ __device__ void GDAContext::getmem_nbi(void *dest, const void *source,
     ipcImpl_.ipcCopy(dest, ipcImpl_.ipc_bases[local_pe] + L_offset, nelems);
     return;
   }
-  uint64_t L_offset = const_cast<char *>(src_typed) - base_heap[my_pe];
-  qps[get_qp_index(pe)].get_nbi(dest, base_heap[pe] + L_offset, nelems, pe);
+  qps[get_qp_index(pe)].get_nbi(dest, get_remote_ptr(source, pe), nelems, pe);
 }
 
 __device__ void GDAContext::fence() { //TODO: optimize
@@ -237,10 +239,9 @@ __device__ void GDAContext::putmem_wg(void *dest, const void *source,
     ipcImpl_.ipcCopy_wg(ipcImpl_.ipc_bases[local_pe] + L_offset, const_cast<void *>(source), nelems);
     return;
   }
-  uint64_t L_offset = reinterpret_cast<char*>(dest) - base_heap[my_pe];
   if (is_wave_zero_in_block()) {
     int qp_index = get_qp_index(pe);
-    qps[qp_index].put_nbi(base_heap[pe] + L_offset, source, nelems, pe, QueuePair::WAVE);
+    qps[qp_index].put_nbi(get_remote_ptr(dest, pe), source, nelems, pe, QueuePair::WAVE);
     qps[qp_index].quiet();
   }
 }
@@ -254,10 +255,9 @@ __device__ void GDAContext::getmem_wg(void *dest, const void *source,
     ipcImpl_.ipcCopy_wg(dest, ipcImpl_.ipc_bases[local_pe] + L_offset, nelems);
     return;
   }
-  uint64_t L_offset = const_cast<char *>(src_typed) - base_heap[my_pe];
   if (is_wave_zero_in_block()) {
     int qp_index = get_qp_index(pe);
-    qps[qp_index].get_nbi(dest, base_heap[pe] + L_offset, nelems, pe, QueuePair::WAVE);
+    qps[qp_index].get_nbi(dest, get_remote_ptr(source, pe), nelems, pe, QueuePair::WAVE);
     qps[qp_index].quiet();
   }
 }
@@ -270,9 +270,8 @@ __device__ void GDAContext::putmem_nbi_wg(void *dest, const void *source,
     ipcImpl_.ipcCopy_wg(ipcImpl_.ipc_bases[local_pe] + L_offset, const_cast<void *>(source), nelems);
     return;
   }
-  uint64_t L_offset = reinterpret_cast<char*>(dest) - base_heap[my_pe];
   if (is_wave_zero_in_block()) {
-    qps[get_qp_index(pe)].put_nbi(base_heap[pe] + L_offset, source, nelems, pe, QueuePair::WAVE);
+    qps[get_qp_index(pe)].put_nbi(get_remote_ptr(dest, pe), source, nelems, pe, QueuePair::WAVE);
   }
 }
 
@@ -285,9 +284,8 @@ __device__ void GDAContext::getmem_nbi_wg(void *dest, const void *source,
     ipcImpl_.ipcCopy_wg(dest, ipcImpl_.ipc_bases[local_pe] + L_offset, nelems);
     return;
   }
-  uint64_t L_offset = const_cast<char *>(src_typed) - base_heap[my_pe];
   if (is_wave_zero_in_block()) {
-    qps[get_qp_index(pe)].get_nbi(dest, base_heap[pe] + L_offset, nelems, pe, QueuePair::WAVE);
+    qps[get_qp_index(pe)].get_nbi(dest, get_remote_ptr(source, pe), nelems, pe, QueuePair::WAVE);
   }
 }
 
@@ -299,9 +297,8 @@ __device__ void GDAContext::putmem_wave(void *dest, const void *source,
     ipcImpl_.ipcCopy_wave(ipcImpl_.ipc_bases[local_pe] + L_offset, const_cast<void *>(source), nelems);
     return;
   }
-  uint64_t L_offset = reinterpret_cast<char*>(dest) - base_heap[my_pe];
   int qp_index = get_qp_index(pe);
-  qps[qp_index].put_nbi(base_heap[pe] + L_offset, source, nelems, pe, QueuePair::WAVE);
+  qps[qp_index].put_nbi(get_remote_ptr(dest, pe), source, nelems, pe, QueuePair::WAVE);
   qps[qp_index].quiet();
 }
 
@@ -314,9 +311,8 @@ __device__ void GDAContext::getmem_wave(void *dest, const void *source,
     ipcImpl_.ipcCopy_wave(dest, ipcImpl_.ipc_bases[local_pe] + L_offset, nelems);
     return;
   }
-  uint64_t L_offset = const_cast<char *>(src_typed) - base_heap[my_pe];
   int qp_index = get_qp_index(pe);
-  qps[qp_index].get_nbi(dest, base_heap[pe] + L_offset, nelems, pe, QueuePair::WAVE);
+  qps[qp_index].get_nbi(dest, get_remote_ptr(source, pe), nelems, pe, QueuePair::WAVE);
   qps[qp_index].quiet();
 }
 
@@ -328,8 +324,7 @@ __device__ void GDAContext::putmem_nbi_wave(void *dest, const void *source,
     ipcImpl_.ipcCopy_wave(ipcImpl_.ipc_bases[local_pe] + L_offset, const_cast<void *>(source), nelems);
     return;
   }
-  uint64_t L_offset = reinterpret_cast<char*>(dest) - base_heap[my_pe];
-  qps[get_qp_index(pe)].put_nbi(base_heap[pe] + L_offset, source, nelems, pe, QueuePair::WAVE);
+  qps[get_qp_index(pe)].put_nbi(get_remote_ptr(dest, pe), source, nelems, pe, QueuePair::WAVE);
 }
 
 __device__ void GDAContext::getmem_nbi_wave(void *dest, const void *source,
@@ -341,8 +336,7 @@ __device__ void GDAContext::getmem_nbi_wave(void *dest, const void *source,
     ipcImpl_.ipcCopy_wave(dest, ipcImpl_.ipc_bases[local_pe] + L_offset, nelems);
     return;
   }
-  uint64_t L_offset = const_cast<char *>(src_typed) - base_heap[my_pe];
-  qps[get_qp_index(pe)].get_nbi(dest, base_heap[pe] + L_offset, nelems, pe, QueuePair::WAVE);
+  qps[get_qp_index(pe)].get_nbi(dest, get_remote_ptr(source, pe), nelems, pe, QueuePair::WAVE);
 }
 
 
@@ -350,8 +344,9 @@ __device__ void GDAContext::getmem_nbi_wave(void *dest, const void *source,
 __device__ void GDAContext::putmem_signal(void *dest, const void *source, size_t nelems,
                                           uint64_t *sig_addr, uint64_t signal, int sig_op,
                                           int pe) {
-  putmem(dest, source, nelems, pe);
-  fence();
+  int qp_index = get_qp_index(pe);
+  qps[qp_index].put_nbi(get_remote_ptr(dest, pe), source, nelems, pe);
+  qps[qp_index].quiet();
 
   switch (sig_op) {
   case ROCSHMEM_SIGNAL_SET:
@@ -370,8 +365,11 @@ __device__ void GDAContext::putmem_signal(void *dest, const void *source, size_t
 __device__ void GDAContext::putmem_signal_wg(void *dest, const void *source, size_t nelems,
                                              uint64_t *sig_addr, uint64_t signal, int sig_op,
                                              int pe) {
-  putmem_wg(dest, source, nelems, pe);
-  fence();
+  if (is_wave_zero_in_block()) {
+    int qp_index = get_qp_index(pe);
+    qps[qp_index].put_nbi(get_remote_ptr(dest, pe), source, nelems, pe, QueuePair::WAVE);
+    qps[qp_index].quiet();
+  }
 
   if (is_thread_zero_in_block()) {
     switch (sig_op) {
@@ -392,8 +390,9 @@ __device__ void GDAContext::putmem_signal_wg(void *dest, const void *source, siz
 __device__ void GDAContext::putmem_signal_wave(void *dest, const void *source, size_t nelems,
                                                uint64_t *sig_addr, uint64_t signal, int sig_op,
                                                int pe) {
-  putmem_wave(dest, source, nelems, pe);
-  fence();
+  int qp_index = get_qp_index(pe);
+  qps[qp_index].put_nbi(get_remote_ptr(dest, pe), source, nelems, pe, QueuePair::WAVE);
+  qps[qp_index].quiet();
 
   if (is_thread_zero_in_wave()) {
     switch (sig_op) {

--- a/src/gda/context_gda_device.cpp
+++ b/src/gda/context_gda_device.cpp
@@ -42,11 +42,29 @@ __host__ GDAContext::GDAContext(Backend *b, unsigned int ctx_id)
   barrier_sync = backend->barrier_sync;
   wrk_sync_pool_bases_ = backend->get_wrk_sync_bases();
 
-  CHECK_HIP(hipMalloc(&qps, sizeof(QueuePair) * num_pes));
-  CHECK_HIP(hipMemset(qps, 0, sizeof(QueuePair) * num_pes));
-  for (int i = 0; i < num_pes; i++) {
-    int offset = num_pes * ctx_id + i;
-    CHECK_HIP(hipMemcpy(&qps[i], &backend->gpu_qps[offset], sizeof(QueuePair), hipMemcpyDefault));
+  ctx_id_ = ctx_id;
+  num_qps_per_pe = ctx_id_?
+      envvar::gda::num_qps_per_pe_usr_ctx.get_value() :
+      envvar::gda::num_qps_per_pe_default_ctx.get_value();
+
+  num_qps = num_qps_per_pe * num_pes;
+
+  // Calculate offset into the backend's GPU QP array
+  int offset = (ctx_id_ > 0) *
+    (envvar::gda::num_qps_per_pe_default_ctx.get_value() +
+     envvar::gda::num_qps_per_pe_usr_ctx.get_value() * (ctx_id_ - 1));
+  offset *= num_pes;
+
+  CHECK_HIP(hipMalloc(&qp_counter, sizeof(uint32_t) * num_pes));
+  CHECK_HIP(hipMemset(qp_counter, 0, sizeof(uint32_t) * num_pes));
+  CHECK_HIP(hipMalloc(&qps, sizeof(QueuePair) * num_qps));
+  CHECK_HIP(hipMemset(qps, 0, sizeof(QueuePair) * num_qps));
+
+  CHECK_HIP(hipMemcpy(qps, &backend->gpu_qps[offset],
+                      num_qps * sizeof(QueuePair),
+                      hipMemcpyDefault));
+
+  for (int i = 0; i < num_qps; i++) {
     qps[i].base_heap = base_heap;
   }
 
@@ -54,12 +72,43 @@ __host__ GDAContext::GDAContext(Backend *b, unsigned int ctx_id)
   ipcImpl_.shm_size = backend->ipcImpl.shm_size;
   ipcImpl_.shm_rank = backend->ipcImpl.shm_rank;
   ipcImpl_.pes_with_ipc_avail = backend->ipcImpl.pes_with_ipc_avail;
-
-  ctx_id_ = ctx_id;
 }
 
 __host__ GDAContext::~GDAContext() {
   CHECK_HIP(hipFree(qps));
+}
+
+/**
+ * @brief Get the Queue Pair index for a given PE based on a atomic counter
+ *        This ensures even distribution of requests across multiple QPs
+ *        allocated per PE.
+ * @param pe The target PE
+ * @return The Queue Pair index
+ *
+ * Explanation of QP indexing scheme:
+ *  num_qps_per_pe = 4
+ *  num_pes        = 3
+ *
+ *  Layout of QPs per PE:
+ *
+ *             PE0          PE1          PE2
+ *           ───────      ───────      ───────
+ *  QP0  ─> [ QP0,0 ]    [ QP0,1 ]    [ QP0,2 ]
+ *  QP1  ─> [ QP1,0 ]    [ QP1,1 ]    [ QP1,2 ]
+ *  QP2  ─> [ QP2,0 ]    [ QP2,1 ]  **[ QP2,2 ]** <-- highlighted (3rd QP of PE2)
+ *  QP3  ─> [ QP3,0 ]    [ QP3,1 ]    [ QP3,2 ]
+ *
+ *  Legend:
+ *    - num_qps_per_pe = 4  →  Four Queue Pairs per PE
+ *    - num_pes = 3         →  Three Processing Elements (PE0–PE2)
+ *    - QP[i,j]             →  i-th QP of PE j
+ *    - **[ QP2,2 ]**       →  The 3rd QP (QP index 2) of PE2
+ */
+__device__ uint32_t GDAContext::get_qp_index(int pe) {
+  uint32_t local_counter = __hip_atomic_fetch_add(&qp_counter[pe], 1,
+                           __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+  uint32_t qp_index = (local_counter % num_qps_per_pe) * num_pes + pe;
+  return qp_index;
 }
 
 __device__ void GDAContext::ctx_create() {

--- a/src/gda/context_gda_device.cpp
+++ b/src/gda/context_gda_device.cpp
@@ -105,9 +105,26 @@ __host__ GDAContext::~GDAContext() {
  *    - **[ QP2,2 ]**       →  The 3rd QP (QP index 2) of PE2
  */
 __device__ uint32_t GDAContext::get_qp_index(int pe) {
-  uint32_t local_counter = __hip_atomic_fetch_add(&qp_counter[pe], 1,
-                           __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
-  uint32_t qp_index = (local_counter % num_qps_per_pe) * num_pes + pe;
+  uint64_t activemask   = get_active_lane_mask();
+  uint64_t same_pe_mask = __match_any_sync(activemask, pe);
+  const int leader_phys_lane_id = get_first_active_lane_id(same_pe_mask);
+  const int my_logical_lane_id  = get_active_lane_num(same_pe_mask);
+
+  uint32_t qp_index   {0};
+
+  if(my_logical_lane_id == 0) {
+    // Only the leader lane updates the counter
+    uint32_t local_qp_counter = __hip_atomic_fetch_add(&qp_counter[pe], 1,
+                                           __ATOMIC_RELAXED,
+                                           __HIP_MEMORY_SCOPE_AGENT);
+    local_qp_counter %= num_qps_per_pe;
+    qp_index = (local_qp_counter * num_pes) + pe;
+  }
+
+  // Broadcast the qp_index value to other lanes in the wavefront
+  // that are targeting the same PE
+  qp_index = __shfl_sync(same_pe_mask, qp_index, leader_phys_lane_id);
+
   return qp_index;
 }
 
@@ -126,8 +143,9 @@ __device__ void GDAContext::putmem(void *dest, const void *source, size_t nelems
     return;
   }
   uint64_t L_offset = reinterpret_cast<char*>(dest) - base_heap[my_pe];
-  qps[pe].put_nbi(base_heap[pe] + L_offset, source, nelems, pe);
-  qps[pe].quiet();
+  int qp_index = get_qp_index(pe);
+  qps[qp_index].put_nbi(base_heap[pe] + L_offset, source, nelems, pe);
+  qps[qp_index].quiet();
 }
 
 __device__ void GDAContext::getmem(void *dest, const void *source, size_t nelems,
@@ -140,8 +158,9 @@ __device__ void GDAContext::getmem(void *dest, const void *source, size_t nelems
     return;
   }
   uint64_t L_offset = const_cast<char *>(src_typed) - base_heap[my_pe];
-  qps[pe].get_nbi(dest, base_heap[pe] + L_offset, nelems, pe);
-  qps[pe].quiet();
+  int qp_index = get_qp_index(pe);
+  qps[qp_index].get_nbi(dest, base_heap[pe] + L_offset, nelems, pe);
+  qps[qp_index].quiet();
 }
 
 __device__ void GDAContext::putmem_nbi(void *dest, const void *source,
@@ -153,7 +172,7 @@ __device__ void GDAContext::putmem_nbi(void *dest, const void *source,
     return;
   }
   uint64_t L_offset = reinterpret_cast<char*>(dest) - base_heap[my_pe];
-  qps[pe].put_nbi(base_heap[pe] + L_offset, source, nelems, pe);
+  qps[get_qp_index(pe)].put_nbi(base_heap[pe] + L_offset, source, nelems, pe);
 }
 
 __device__ void GDAContext::getmem_nbi(void *dest, const void *source,
@@ -166,11 +185,11 @@ __device__ void GDAContext::getmem_nbi(void *dest, const void *source,
     return;
   }
   uint64_t L_offset = const_cast<char *>(src_typed) - base_heap[my_pe];
-  qps[pe].get_nbi(dest, base_heap[pe] + L_offset, nelems, pe);
+  qps[get_qp_index(pe)].get_nbi(dest, base_heap[pe] + L_offset, nelems, pe);
 }
 
 __device__ void GDAContext::fence() { //TODO: optimize
-  for (int i = 0; i < num_pes; i++) {
+  for (int i = 0; i < num_qps; i++) {
     qps[i].quiet();
   }
   __threadfence_system();
@@ -181,19 +200,22 @@ __device__ void GDAContext::fence(int pe) {
 }
 
 __device__ void GDAContext::quiet() {
-  for (int i = 0; i < num_pes; i++) {
+  for (int i = 0; i < num_qps; i++) {
     qps[i].quiet();
   }
 }
 
 __device__ void GDAContext::quiet_wave() {
-  for (int i = 0; i < num_pes; i++) {
+  for (int i = 0; i < num_qps; i++) {
     qps[i].quiet(QueuePair::WAVE);
   }
 }
 
 __device__ void GDAContext::pe_quiet(size_t pe) {
-  qps[pe].quiet();
+  for(int i = 0; i < num_qps_per_pe; i++) {
+    int qp_index = i * num_pes + pe;
+    qps[qp_index].quiet();
+  }
 }
 
 __device__ void *GDAContext::shmem_ptr(const void *dest, int pe) {
@@ -217,8 +239,9 @@ __device__ void GDAContext::putmem_wg(void *dest, const void *source,
   }
   uint64_t L_offset = reinterpret_cast<char*>(dest) - base_heap[my_pe];
   if (is_wave_zero_in_block()) {
-    qps[pe].put_nbi(base_heap[pe] + L_offset, source, nelems, pe, QueuePair::WAVE);
-    qps[pe].quiet();
+    int qp_index = get_qp_index(pe);
+    qps[qp_index].put_nbi(base_heap[pe] + L_offset, source, nelems, pe, QueuePair::WAVE);
+    qps[qp_index].quiet();
   }
 }
 
@@ -233,8 +256,9 @@ __device__ void GDAContext::getmem_wg(void *dest, const void *source,
   }
   uint64_t L_offset = const_cast<char *>(src_typed) - base_heap[my_pe];
   if (is_wave_zero_in_block()) {
-    qps[pe].get_nbi(dest, base_heap[pe] + L_offset, nelems, pe, QueuePair::WAVE);
-    qps[pe].quiet();
+    int qp_index = get_qp_index(pe);
+    qps[qp_index].get_nbi(dest, base_heap[pe] + L_offset, nelems, pe, QueuePair::WAVE);
+    qps[qp_index].quiet();
   }
 }
 
@@ -248,7 +272,7 @@ __device__ void GDAContext::putmem_nbi_wg(void *dest, const void *source,
   }
   uint64_t L_offset = reinterpret_cast<char*>(dest) - base_heap[my_pe];
   if (is_wave_zero_in_block()) {
-    qps[pe].put_nbi(base_heap[pe] + L_offset, source, nelems, pe, QueuePair::WAVE);
+    qps[get_qp_index(pe)].put_nbi(base_heap[pe] + L_offset, source, nelems, pe, QueuePair::WAVE);
   }
 }
 
@@ -263,7 +287,7 @@ __device__ void GDAContext::getmem_nbi_wg(void *dest, const void *source,
   }
   uint64_t L_offset = const_cast<char *>(src_typed) - base_heap[my_pe];
   if (is_wave_zero_in_block()) {
-    qps[pe].get_nbi(dest, base_heap[pe] + L_offset, nelems, pe, QueuePair::WAVE);
+    qps[get_qp_index(pe)].get_nbi(dest, base_heap[pe] + L_offset, nelems, pe, QueuePair::WAVE);
   }
 }
 
@@ -276,8 +300,9 @@ __device__ void GDAContext::putmem_wave(void *dest, const void *source,
     return;
   }
   uint64_t L_offset = reinterpret_cast<char*>(dest) - base_heap[my_pe];
-  qps[pe].put_nbi(base_heap[pe] + L_offset, source, nelems, pe, QueuePair::WAVE);
-  qps[pe].quiet();
+  int qp_index = get_qp_index(pe);
+  qps[qp_index].put_nbi(base_heap[pe] + L_offset, source, nelems, pe, QueuePair::WAVE);
+  qps[qp_index].quiet();
 }
 
 __device__ void GDAContext::getmem_wave(void *dest, const void *source,
@@ -290,8 +315,9 @@ __device__ void GDAContext::getmem_wave(void *dest, const void *source,
     return;
   }
   uint64_t L_offset = const_cast<char *>(src_typed) - base_heap[my_pe];
-  qps[pe].get_nbi(dest, base_heap[pe] + L_offset, nelems, pe, QueuePair::WAVE);
-  qps[pe].quiet();
+  int qp_index = get_qp_index(pe);
+  qps[qp_index].get_nbi(dest, base_heap[pe] + L_offset, nelems, pe, QueuePair::WAVE);
+  qps[qp_index].quiet();
 }
 
 __device__ void GDAContext::putmem_nbi_wave(void *dest, const void *source,
@@ -303,7 +329,7 @@ __device__ void GDAContext::putmem_nbi_wave(void *dest, const void *source,
     return;
   }
   uint64_t L_offset = reinterpret_cast<char*>(dest) - base_heap[my_pe];
-  qps[pe].put_nbi(base_heap[pe] + L_offset, source, nelems, pe, QueuePair::WAVE);
+  qps[get_qp_index(pe)].put_nbi(base_heap[pe] + L_offset, source, nelems, pe, QueuePair::WAVE);
 }
 
 __device__ void GDAContext::getmem_nbi_wave(void *dest, const void *source,
@@ -316,7 +342,7 @@ __device__ void GDAContext::getmem_nbi_wave(void *dest, const void *source,
     return;
   }
   uint64_t L_offset = const_cast<char *>(src_typed) - base_heap[my_pe];
-  qps[pe].get_nbi(dest, base_heap[pe] + L_offset, nelems, pe, QueuePair::WAVE);
+  qps[get_qp_index(pe)].get_nbi(dest, base_heap[pe] + L_offset, nelems, pe, QueuePair::WAVE);
 }
 
 

--- a/src/gda/context_gda_device.hpp
+++ b/src/gda/context_gda_device.hpp
@@ -288,6 +288,11 @@ class GDAContext : public Context {
    */
   __device__ uint32_t get_qp_index(int pe);
 
+  /**
+   * @brief Get the destination pointer for a given PE
+   */
+  __device__ char* get_remote_ptr(const void* addr, int pe);
+
   //Temporary scratchpad memory used by internal barrier algorithms.
   int64_t *barrier_sync{nullptr};
 
@@ -320,6 +325,9 @@ class GDAContext : public Context {
  public:
   QueuePair *qps{nullptr};
 
+  /**
+   * @brief Base heap pointers for all PEs
+   */
   char *const *base_heap{nullptr};
 
   //TODO(Avinash):

--- a/src/gda/context_gda_device.hpp
+++ b/src/gda/context_gda_device.hpp
@@ -283,6 +283,10 @@ class GDAContext : public Context {
                                           int nelems, GDATeam *team_obj,
                                           int n_seg, int seg_size, int chunk_size);
 
+  /**
+   * @brief Get the Queue Pair index to use for a given PE
+   */
+  __device__ uint32_t get_qp_index(int pe);
 
   //Temporary scratchpad memory used by internal barrier algorithms.
   int64_t *barrier_sync{nullptr};
@@ -297,6 +301,21 @@ class GDAContext : public Context {
    * @brief Device context Id
    */
   unsigned int ctx_id_{};
+
+  /**
+   * @brief Number of Queue Pairs allocated per PE
+   */
+  uint32_t num_qps_per_pe {1};
+
+  /**
+   * @brief Total number of Queue Pairs allocated = num_qps_per_pe * num_pes
+   */
+  uint32_t num_qps {1};
+
+  /**
+   * @brief Device pointer to the qp_counter variable to pcick next qp index
+   */
+  uint32_t *qp_counter {nullptr};
 
  public:
   QueuePair *qps{nullptr};

--- a/src/gda/context_gda_tmpl_device.hpp
+++ b/src/gda/context_gda_tmpl_device.hpp
@@ -95,11 +95,12 @@ __device__ void GDAContext::amo_add(void *dst, T value, int pe) {
   uint64_t L_offset = reinterpret_cast<char *>(dst) - base_heap[my_pe];
   bool need_turn {true};
   uint64_t turns = __ballot(need_turn);
+  int qp_index = get_qp_index(pe);
   while (turns) {
     uint8_t lane = __ffsll((unsigned long long)turns) - 1;
     int pe_turn = __shfl(pe, lane);
     if (pe_turn == pe) {
-      qps[pe].atomic_nofetch(base_heap[pe] + L_offset, value, 0, pe);
+      qps[qp_index].atomic_nofetch(base_heap[pe] + L_offset, value, 0, pe);
       need_turn = false;
     }
     turns = __ballot(need_turn);
@@ -119,6 +120,7 @@ __device__ T GDAContext::amo_swap(void *dst, T value, int pe) {
   uint64_t turns = __ballot(need_turn);
   T ret_val;
   T cond = 0;
+  int qp_index = get_qp_index(pe);
   while (turns) {
     uint8_t lane = __ffsll((unsigned long long)turns) - 1;
     int pe_turn = __shfl(pe, lane);
@@ -128,7 +130,7 @@ __device__ T GDAContext::amo_swap(void *dst, T value, int pe) {
        * The compare-and-swap loop will execute at least twice if wrong.
        * It may run additional times if contention on memory location.
        */
-      while ((ret_val = qps[pe].atomic_cas(base_heap[pe] + L_offset, value,
+      while ((ret_val = qps[qp_index].atomic_cas(base_heap[pe] + L_offset, value,
                          cond, pe)) != cond) {
         cond = ret_val;
       }
@@ -148,11 +150,12 @@ __device__ T GDAContext::amo_fetch_and(void *dst, T value, int pe) {
   T ret_val;
   T cond = 0;
   T desired_val = cond & value;
+  int qp_index = get_qp_index(pe);
   while (turns) {
     uint8_t lane = __ffsll((unsigned long long)turns) - 1;
     int pe_turn = __shfl(pe, lane);
     if (pe_turn == pe) {
-      while ((ret_val = qps[pe].atomic_cas(base_heap[pe] + L_offset,
+      while ((ret_val = qps[qp_index].atomic_cas(base_heap[pe] + L_offset,
                          desired_val, cond, pe)) != cond) {
         cond = ret_val;
         desired_val = ret_val & value;
@@ -178,11 +181,12 @@ __device__ T GDAContext::amo_fetch_or(void *dst, T value, int pe) {
   T ret_val;
   T cond = 0;
   T desired_val = cond | value;
+  int qp_index = get_qp_index(pe);
   while (turns) {
     uint8_t lane = __ffsll((unsigned long long)turns) - 1;
     int pe_turn = __shfl(pe, lane);
     if (pe_turn == pe) {
-      while ((ret_val = qps[pe].atomic_cas(base_heap[pe] + L_offset,
+      while ((ret_val = qps[qp_index].atomic_cas(base_heap[pe] + L_offset,
                          desired_val, cond, pe)) != cond) {
         cond = ret_val;
         desired_val = ret_val | value;
@@ -208,11 +212,12 @@ __device__ T GDAContext::amo_fetch_xor(void *dst, T value, int pe) {
   T ret_val;
   T cond = 0;
   T desired_val = cond ^ value;
+  int qp_index = get_qp_index(pe);
   while (turns) {
     uint8_t lane = __ffsll((unsigned long long)turns) - 1;
     int pe_turn = __shfl(pe, lane);
     if (pe_turn == pe) {
-      while ((ret_val = qps[pe].atomic_cas(base_heap[pe] + L_offset,
+      while ((ret_val = qps[qp_index].atomic_cas(base_heap[pe] + L_offset,
                          desired_val, cond, pe)) != cond) {
         cond = ret_val;
         desired_val = ret_val ^ value;
@@ -235,11 +240,12 @@ __device__ void GDAContext::amo_cas(void *dst, T value, T cond, int pe) {
   uint64_t L_offset = reinterpret_cast<char *>(dst) - base_heap[my_pe];
   bool need_turn {true};
   uint64_t turns = __ballot(need_turn);
+  int qp_index = get_qp_index(pe);
   while (turns) {
     uint8_t lane = __ffsll((unsigned long long)turns) - 1;
     int pe_turn = __shfl(pe, lane);
     if (pe_turn == pe) {
-      qps[pe].atomic_cas_nofetch(base_heap[pe] + L_offset, value, cond, pe);
+      qps[qp_index].atomic_cas_nofetch(base_heap[pe] + L_offset, value, cond, pe);
       need_turn = false;
     }
     turns = __ballot(need_turn);
@@ -253,11 +259,12 @@ __device__ T GDAContext::amo_fetch_add(void *dst, T value, int pe) {
   T ret_val = 0;
   bool need_turn {true};
   uint64_t turns = __ballot(need_turn);
+  int qp_index = get_qp_index(pe);
   while (turns) {
     uint8_t lane = __ffsll((unsigned long long)turns) - 1;
     int pe_turn = __shfl(pe, lane);
     if (pe_turn == pe) {
-      ret_val =  qps[pe].atomic_fetch(base_heap[pe] + L_offset, value, 0, pe);
+      ret_val =  qps[qp_index].atomic_fetch(base_heap[pe] + L_offset, value, 0, pe);
       need_turn = false;
     }
     turns = __ballot(need_turn);
@@ -272,11 +279,12 @@ __device__ T GDAContext::amo_fetch_cas(void *dst, T value, T cond, int pe) {
   bool need_turn {true};
   uint64_t turns = __ballot(need_turn);
   T ret_val;
+  int qp_index = get_qp_index(pe);
   while (turns) {
     uint8_t lane = __ffsll((unsigned long long)turns) - 1;
     int pe_turn = __shfl(pe, lane);
     if (pe_turn == pe) {
-      ret_val = qps[pe].atomic_cas(base_heap[pe] + L_offset, value, cond, pe);
+      ret_val = qps[qp_index].atomic_cas(base_heap[pe] + L_offset, value, cond, pe);
       need_turn = false;
     }
     turns = __ballot(need_turn);


### PR DESCRIPTION
## Motivation
- This PR adds support for configurable QP allocation per PE in the GDA context.
- It introduces environment variables to control the number of QPs for the default and user contexts.
- Previously, the number of QPs per PE was fixed to 1.

AIROCSHMEM-7

## Technical Details
#### Environment Variables
- Added two new environment variables to configure QP allocation:
  - `ROCSHMEM_GDA_NUM_QPS_PER_PE_DEFAULT_CTX`: Number of QPs per PE in the default context.
  - `ROCSHMEM_GDA_NUM_QPS_PER_PE_USR_CTX`: Number of QPs per PE in each user context.
- Introduced `get_qp_index()` device method to compute QP index using atomic counter
  for round-robin access.
## Test Plan
- Verify correctness by initializing multiple contexts with varying environment variable values.
- Verifiy functionality and correctness across all three NIC types: mlx, bnxt, and ionic.
- Measure and validate performance improvements with configurable QP allocation under different workloads.

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Code compiles successfully
- [x] All relevant unit tests pass
- [ ] Verified behavior under multiple context configurations
- [x] Verified functionality and performance improvements with mlx
- [ ] Verified functionality and performance improvements with bnxt
- [ ] Verified functionality and performance improvements with ionic