### PR TITLE
AIROCSHMEM-201 - gda: add check for active interfaces when selecting the GDA backend

### DIFF
--- a/src/gda/backend_gda.cpp
+++ b/src/gda/backend_gda.cpp
@@ -547,9 +547,68 @@ GDAProvider GDABackend::requested_provider() {
   return GDAProvider::UNSET;
 }
 
-/* Currently we only check whether we can dlopen a Direct Verbs library.
- * We might need to extend this logic to check whether we have interfaces that
- * can use those DV libraries
+/* Check whether there are active InfiniBand/RDMA interfaces available.
+ * For BNXT, also verifies the device vendor matches to avoid selecting
+ * the wrong NIC when multiple vendors are present.
+ * Returns true if at least one active port is found on a suitable device.
+ */
+bool GDABackend::has_active_ib_interface(GDAProvider provider) {
+  struct ibv_device **device_list = nullptr;
+  int num_devices = 0;
+  bool has_active = false;
+
+  device_list = ibv.get_device_list(&num_devices);
+  if (!device_list || num_devices == 0) {
+    DPRINTF("No InfiniBand devices found\n");
+    return false;
+  }
+
+  for (int i = 0; i < num_devices && !has_active; i++) {
+    struct ibv_context *context = ibv.open_device(device_list[i]);
+    if (!context) {
+      continue;
+    }
+
+    struct ibv_device_attr device_attr;
+    if (ibv.query_device(context, &device_attr) == 0) {
+      if (provider == GDAProvider::BNXT) {
+        const uint32_t BNXT_VENDOR_ID = 0x14E4;
+        if (device_attr.vendor_id != BNXT_VENDOR_ID) {
+          DPRINTF("Skipping device %s with vendor_id=0x%04x (not BNXT/Broadcom)\n",
+                  ibv.get_device_name(device_list[i]), device_attr.vendor_id);
+          ibv.close_device(context);
+          continue;
+        }
+      }
+
+      for (int port = 1; port <= device_attr.phys_port_cnt; ++port) {
+        struct ibv_port_attr port_attr;
+        if (ibv.query_port(context, port, &port_attr) == 0) {
+          if (port_attr.state == IBV_PORT_ACTIVE) {
+            DPRINTF("Found active InfiniBand port %d on device %s (vendor_id=0x%04x, state=%d, phys_state=%d)\n",
+                    port, ibv.get_device_name(device_list[i]),
+                    device_attr.vendor_id, port_attr.state, port_attr.phys_state);
+            has_active = true;
+            break;
+          }
+        }
+      }
+    }
+
+    ibv.close_device(context);
+  }
+
+  ibv.free_device_list(device_list);
+
+  if (!has_active) {
+    DPRINTF("No active InfiniBand ports found on any device\n");
+  }
+
+  return has_active;
+}
+
+/* Check whether we can dlopen a Direct Verbs library and verify that
+ * there are active InfiniBand/RDMA interfaces available to use.
  */
 int GDABackend::backend_can_run() {
   void *handle{nullptr};
@@ -561,7 +620,10 @@ int GDABackend::backend_can_run() {
     handle = bnxt_dv_dlopen();
     if (handle) {
       dlclose(handle);
-      return ROCSHMEM_SUCCESS;
+      if (has_active_ib_interface(GDAProvider::BNXT)) {
+        return ROCSHMEM_SUCCESS;
+      }
+      DPRINTF("BNXT DV library found but no active InfiniBand interface available\n");
     }
   }
 #endif //defined(GDA_BNXT)
@@ -572,7 +634,10 @@ int GDABackend::backend_can_run() {
     handle = ionic_dv_dlopen();
     if (handle) {
       dlclose(handle);
-      return ROCSHMEM_SUCCESS;
+      if (has_active_ib_interface(GDAProvider::IONIC)) {
+        return ROCSHMEM_SUCCESS;
+      }
+      DPRINTF("IONIC DV library found but no active InfiniBand interface available\n");
     }
   }
 #endif //defined(GDA_IONIC)
@@ -583,7 +648,10 @@ int GDABackend::backend_can_run() {
     handle = mlx5_dv_dlopen();
     if (handle) {
       dlclose(handle);
-      return ROCSHMEM_SUCCESS;
+      if (has_active_ib_interface(GDAProvider::MLX5)) {
+        return ROCSHMEM_SUCCESS;
+      }
+      DPRINTF("MLX5 DV library found but no active InfiniBand interface available\n");
     }
   }
 #endif //defined(GDA_MLX5)

--- a/src/gda/backend_gda.cpp
+++ b/src/gda/backend_gda.cpp
@@ -547,10 +547,48 @@ GDAProvider GDABackend::requested_provider() {
   return GDAProvider::UNSET;
 }
 
+/* Check if a device's vendor ID matches the expected vendor for a given provider.
+ * Returns true if the device matches, false otherwise.
+ */
+bool GDABackend::device_matches_provider_vendor(GDAProvider provider,
+                                                 const struct ibv_device_attr &device_attr,
+                                                 const char *device_name) {
+  uint32_t expected_vendor_id = 0;
+  const char *vendor_name = nullptr;
+
+  switch (provider) {
+    case GDAProvider::BNXT:
+      expected_vendor_id = GDA_BNXT_VENDOR_ID;
+      vendor_name = "BNXT/Broadcom";
+      break;
+    case GDAProvider::IONIC:
+      expected_vendor_id = GDA_IONIC_VENDOR_ID;
+      vendor_name = "IONIC/Pensando";
+      break;
+    case GDAProvider::MLX5:
+      expected_vendor_id = GDA_MLX5_VENDOR_ID;
+      vendor_name = "MLX5/Mellanox";
+      break;
+    case GDAProvider::UNSET:
+      // UNSET accepts any vendor
+      return true;
+    default:
+      return true;
+  }
+
+  if (device_attr.vendor_id != expected_vendor_id) {
+    DPRINTF("Skipping device %s with vendor_id=0x%04x (not %s)\n",
+            device_name, device_attr.vendor_id, vendor_name);
+    return false;
+  }
+
+  return true;
+}
+
 /* Check whether there are active InfiniBand/RDMA interfaces available.
- * For BNXT, also verifies the device vendor matches to avoid selecting
+ * Verifies the device vendor matches the requested provider to avoid selecting
  * the wrong NIC when multiple vendors are present.
- * Returns true if at least one active port is found on a suitable device.
+ * Returns true if at least one active port is found on a matching device.
  */
 bool GDABackend::has_active_ib_interface(GDAProvider provider) {
   struct ibv_device **device_list = nullptr;
@@ -571,14 +609,11 @@ bool GDABackend::has_active_ib_interface(GDAProvider provider) {
 
     struct ibv_device_attr device_attr;
     if (ibv.query_device(context, &device_attr) == 0) {
-      if (provider == GDAProvider::BNXT) {
-        const uint32_t BNXT_VENDOR_ID = 0x14E4;
-        if (device_attr.vendor_id != BNXT_VENDOR_ID) {
-          DPRINTF("Skipping device %s with vendor_id=0x%04x (not BNXT/Broadcom)\n",
-                  ibv.get_device_name(device_list[i]), device_attr.vendor_id);
-          ibv.close_device(context);
-          continue;
-        }
+      // Check if device vendor matches the provider
+      if (!device_matches_provider_vendor(provider, device_attr,
+                                          ibv.get_device_name(device_list[i]))) {
+        ibv.close_device(context);
+        continue;
       }
 
       for (int port = 1; port <= device_attr.phys_port_cnt; ++port) {
@@ -958,11 +993,10 @@ void GDABackend::validate_ib_device() {
   CHECK_ZERO(err, "ibv_query_device");
 
   if (gda_provider == GDAProvider::BNXT) {
-    const uint32_t bnxt_vendor_id =  0x14E4;
     const std::set<uint32_t> supported_bnxt_part_ids = { 0x1760 /* BCM57608 */};
     const char min_supported_bnxt_fw_ver[12] = "233.2.104.0";
 
-    if (bnxt_vendor_id != device_attr.vendor_id) {
+    if (device_attr.vendor_id != GDA_BNXT_VENDOR_ID) {
       printf("%s GDAProvider::BNXT requested but an invalid device is selected\n", debug_str.c_str());
       exit(1);
     }

--- a/src/gda/backend_gda.cpp
+++ b/src/gda/backend_gda.cpp
@@ -559,7 +559,7 @@ bool GDABackend::has_active_ib_interface(GDAProvider provider) {
 
   device_list = ibv.get_device_list(&num_devices);
   if (!device_list || num_devices == 0) {
-    DPRINTF("No InfiniBand devices found\n");
+    DPRINTF("No RDMA NIC devices found\n");
     return false;
   }
 
@@ -585,7 +585,7 @@ bool GDABackend::has_active_ib_interface(GDAProvider provider) {
         struct ibv_port_attr port_attr;
         if (ibv.query_port(context, port, &port_attr) == 0) {
           if (port_attr.state == IBV_PORT_ACTIVE) {
-            DPRINTF("Found active InfiniBand port %d on device %s (vendor_id=0x%04x, state=%d, phys_state=%d)\n",
+            DPRINTF("Found active RDMA NIC port %d on device %s (vendor_id=0x%04x, state=%d, phys_state=%d)\n",
                     port, ibv.get_device_name(device_list[i]),
                     device_attr.vendor_id, port_attr.state, port_attr.phys_state);
             has_active = true;

--- a/src/gda/backend_gda.hpp
+++ b/src/gda/backend_gda.hpp
@@ -55,6 +55,10 @@ enum GDAProvider {
   MLX5
 };
 
+inline constexpr uint32_t GDA_IONIC_VENDOR_ID = 0x1DD8;
+inline constexpr uint32_t GDA_MLX5_VENDOR_ID  = 0x15B3;
+inline constexpr uint32_t GDA_BNXT_VENDOR_ID  = 0x14E4;
+
 class GDABackend : public Backend {
  private:
   typedef struct dest_info {
@@ -132,11 +136,23 @@ class GDABackend : public Backend {
   virtual ~GDABackend();
 
   /**
-   * @brief Check if there are active InfiniBand/RDMA interfaces available.
-   *        For BNXT, also verifies the device vendor matches.
+   * @brief Check if a device's vendor ID matches the expected vendor for a provider
    *
-   * @param provider The GDA provider to check for
-   * @return true if at least one active port on a suitable device is found,
+   * @param provider The GDA provider to check against
+   * @param device_attr The device attributes containing the vendor ID
+   * @param device_name The device name (for debug messages)
+   * @return true if the device vendor matches the provider, false otherwise
+   */
+  static bool device_matches_provider_vendor(GDAProvider provider,
+                                             const struct ibv_device_attr &device_attr,
+                                             const char *device_name);
+
+  /**
+   * @brief Check if there are active InfiniBand/RDMA interfaces available
+   *        that match the specified provider's vendor ID.
+   *
+   * @param provider The GDA provider to check for (BNXT, IONIC, or MLX5)
+   * @return true if at least one active port on a matching vendor device is found,
    *         false otherwise
    */
   static bool has_active_ib_interface(GDAProvider provider);

--- a/src/gda/backend_gda.hpp
+++ b/src/gda/backend_gda.hpp
@@ -132,6 +132,16 @@ class GDABackend : public Backend {
   virtual ~GDABackend();
 
   /**
+   * @brief Check if there are active InfiniBand/RDMA interfaces available.
+   *        For BNXT, also verifies the device vendor matches.
+   *
+   * @param provider The GDA provider to check for
+   * @return true if at least one active port on a suitable device is found,
+   *         false otherwise
+   */
+  static bool has_active_ib_interface(GDAProvider provider);
+
+  /**
    * @brief Verify whether GDA Backend could run
    *
    * @return ROSCHMEM_SUCCESS if GDA Backend can most likely be used

--- a/src/rocshmem_gpu.cpp
+++ b/src/rocshmem_gpu.cpp
@@ -498,7 +498,7 @@ __device__ void rocshmem_ctx_quiet(rocshmem_ctx_t ctx) {
 }
 
 __device__ void rocshmem_ctx_pe_quiet(rocshmem_ctx_t ctx, const int *target_pes, size_t npes) {
-  GPU_DPRINTF("Function: %s (ctx=%zd)\n", __FUNC__, ctx.ctx_opaque);
+  GPU_DPRINTF("Function: %s (ctx=%zd)\n", __func__, ctx.ctx_opaque);
 
   ContextTy *internal_ctx = get_internal_ctx(ctx);
 


### PR DESCRIPTION
## Motivation

Ticket: AIROCSHMEM-201

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

Add checks to ensure GDA backend only activates when:
- Direct Verbs library can be opened
- Active RDMA interfaces exist (IBV_PORT_ACTIVE)
- Device vendor matches provider (BNXT/IONIC/MLX5)

This prevents crashes when libraries are installed but hardware is
unavailable or mismatched.

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

Default functional and manual testing.

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

Manual testing:

Case 1 (Matching provider and hardware. Broadcom + bnxt provider):

 ROCSHMEM_GDA_PROVIDER=bnxt mpirun --oversubscribe -np 2 examples/rocshmem_alltoall_test
```
Found active InfiniBand port 1 on device bnxt_re0 (vendor_id=0x14e4, state=4, phys_state=5)
GDABackend::backend_can_run returned success
Initializing GDA backend using MPI
Found active InfiniBand port 1 on device bnxt_re0 (vendor_id=0x14e4, state=4, phys_state=5)
GDABackend::backend_can_run returned success
Initializing GDA backend using MPI
GPU Device id: 0 closest NIC id : 0 name: bnxt_re0
GPU Device id: 1 closest NIC id : 2 name: bnxt_re2
```

Case 2 (Provider and hardware mismatch. Broadcom + mlx5 provider):

 ROCSHMEM_GDA_PROVIDER=mlx5 mpirun --oversubscribe -np 2 examples/rocshmem_alltoall_test
```
Found environment variable ROCSHMEM_GDA_PROVIDER, value is mlx5
Found environment variable ROCSHMEM_GDA_PROVIDER, value is mlx5
Skipping device bnxt_re0 with vendor_id=0x14e4 (not MLX5/Mellanox)
Skipping device bnxt_re1 with vendor_id=0x14e4 (not MLX5/Mellanox)
Skipping device bnxt_re2 with vendor_id=0x14e4 (not MLX5/Mellanox)
Skipping device bnxt_re3 with vendor_id=0x14e4 (not MLX5/Mellanox)
Skipping device bnxt_re4 with vendor_id=0x14e4 (not MLX5/Mellanox)
Skipping device bnxt_re0 with vendor_id=0x14e4 (not MLX5/Mellanox)
Skipping device bnxt_re5 with vendor_id=0x14e4 (not MLX5/Mellanox)
Skipping device bnxt_re1 with vendor_id=0x14e4 (not MLX5/Mellanox)
Skipping device bnxt_re6 with vendor_id=0x14e4 (not MLX5/Mellanox)
Skipping device bnxt_re2 with vendor_id=0x14e4 (not MLX5/Mellanox)
Skipping device bnxt_re7 with vendor_id=0x14e4 (not MLX5/Mellanox)
Skipping device bnxt_re3 with vendor_id=0x14e4 (not MLX5/Mellanox)
Skipping device bnxt_re8 with vendor_id=0x14e4 (not MLX5/Mellanox)
Skipping device bnxt_re4 with vendor_id=0x14e4 (not MLX5/Mellanox)
Skipping device bnxt_re9 with vendor_id=0x14e4 (not MLX5/Mellanox)
No active InfiniBand ports found on any device
MLX5 DV library found but no active InfiniBand interface available
MPIInstance could dl_init MPI library
Initializing RO backend using MPI
Skipping device bnxt_re5 with vendor_id=0x14e4 (not MLX5/Mellanox)
Skipping device bnxt_re6 with vendor_id=0x14e4 (not MLX5/Mellanox)
Skipping device bnxt_re7 with vendor_id=0x14e4 (not MLX5/Mellanox)
Skipping device bnxt_re8 with vendor_id=0x14e4 (not MLX5/Mellanox)
Skipping device bnxt_re9 with vendor_id=0x14e4 (not MLX5/Mellanox)
No active InfiniBand ports found on any device
MLX5 DV library found but no active InfiniBand interface available
MPIInstance could dl_init MPI library
Initializing RO backend using MPI
Host function: rocshmem_barrier_all
Function: ro_net_host_barrier_all
Host function: rocshmem_barrier_all
Function: ro_net_host_barrier_all
Host function: rocshmem_barrier_all
Function: ro_net_host_barrier_all
Host function: rocshmem_barrier_all
Function: ro_net_host_barrier_all
WG (0, 0, 0) TH (0, 0, 0) Function: rocshmem_wg_ctx_create (options=0)
WG (0, 0, 0) TH (0, 0, 0) Function: rocshmem_wg_ctx_create (options=0)
WG (0, 0, 0) TH (192, 0, 0) Function: rocshmem_wg_ctx_create (options=0)
...
WG (0, 0, 0) TH (63, 0, 0) Function: rocshmem_wg_ctx_destroy (ctx=127758977888256)
WG (0, 0, 0) TH (60, 0, 0) Function: rocshmem_wg_ctx_destroy (ctx=124430933979136)
WG (0, 0, 0) TH (61, 0, 0) Function: rocshmem_wg_ctx_destroy (ctx=124430933979136)
WG (0, 0, 0) TH (62, 0, 0) Function: rocshmem_wg_ctx_destroy (ctx=124430933979136)
WG (0, 0, 0) TH (63, 0, 0) Function: rocshmem_wg_ctx_destroy (ctx=124430933979136)
Test examples/rocshmem_alltoall_test     nelem 256 [PASS]
Host function: rocshmem_barrier_all
Function: ro_net_host_barrier_all
Test examples/rocshmem_alltoall_test     nelem 256 [PASS]
Host function: rocshmem_barrier_all
Function: ro_net_host_barrier_all
Host function: rocshmem_barrier_all
Function: ro_net_host_barrier_all
Host function: rocshmem_barrier_all
Function: ro_net_host_barrier_all
```

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
