### PR TITLE
reenable gfx1100

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,6 +108,7 @@ include(cmake/rocm_local_targets.cmake)
 set(DEFAULT_GPUS
     gfx90a:xnack-;
     gfx90a:xnack+;
+    gfx1100;
     gfx1201;
     gfx942)
 

--- a/src/assembly.hpp
+++ b/src/assembly.hpp
@@ -221,15 +221,16 @@ __device__ __forceinline__ void store_asm(uint8_t* val, uint8_t* dst,
                                           int size) {
   switch (size) {
     case 2: {
-      int16_t val16{*(reinterpret_cast<int16_t*>(val))};
 #if defined(__gfx906__)
 #endif
 #if defined(__gfx908__)
 #endif
 #if defined(__gfx90a__)
+      int16_t val16{*(reinterpret_cast<int16_t*>(val))};
       asm volatile("flat_store_short %0 %1 glc slc" : : "v"(dst), "v"(val16));
 #endif
 #if defined(__gfx942__) || defined(__gfx950__)
+      int16_t val16{*(reinterpret_cast<int16_t*>(val))};
       asm volatile("flat_store_short %0 %1 sc0 sc1" : : "v"(dst), "v"(val16));
 #endif
 #if defined(__gfx1100__)
@@ -237,7 +238,8 @@ __device__ __forceinline__ void store_asm(uint8_t* val, uint8_t* dst,
       asm volatile("flat_store_short %0 %1 glc slc" : : "v"(dst), "v"(val32));
 #endif
 #if defined(__gfx1201__)
-      asm volatile("flat_store_b16 %0 %1 scope:SCOPE_SYS" : : "v"(dst), "v"(val16));
+      int32_t val32{*(reinterpret_cast<int32_t*>(val))};
+      asm volatile("flat_store_b16 %0 %1 scope:SCOPE_SYS" : : "v"(dst), "v"(val32));
 #endif
       break;
     }

--- a/src/assembly.hpp
+++ b/src/assembly.hpp
@@ -44,9 +44,9 @@ __device__ __forceinline__ int uncached_load_ubyte(uint8_t* src) {
   int ret;
 #if defined(__gfx906__)
 #endif
-#if defined(__gfx908__) || defined(__gfx1100__)
+#if defined(__gfx908__)
 #endif
-#if defined(__gfx90a__)
+#if defined(__gfx90a__) || defined(__gfx1100__)
   asm volatile(
       "global_load_ubyte %0 %1 off glc slc \n"
       "s_waitcnt vmcnt(0)"
@@ -74,9 +74,9 @@ __device__ __forceinline__ void refresh_volatile_sbyte(volatile int *assigned_va
                                                        volatile char *read_value) {
 #if defined(__gfx906__)
 #endif
-#if defined(__gfx908__) || defined(__gfx1100__)
+#if defined(__gfx908__)
 #endif
-#if defined(__gfx90a__)
+#if defined(__gfx90a__) || defined(__gfx1100__)
   asm volatile(
     "global_load_sbyte %0 %1 off glc slc\n "
     "s_waitcnt vmcnt(0)"
@@ -103,9 +103,9 @@ __device__ __forceinline__ void refresh_volatile_dwordx2(volatile uint64_t *assi
                                                          volatile uint64_t *read_value) {
 #if defined(__gfx906__)
 #endif
-#if defined(__gfx908__) || defined(__gfx1100__)
+#if defined(__gfx908__)
 #endif
-#if defined(__gfx90a__)
+#if defined(__gfx90a__) || defined(__gfx1100__)
   asm volatile(
     "global_load_dwordx2 %0 %1 off glc slc\n "
     "s_waitcnt vmcnt(0)"
@@ -141,9 +141,9 @@ NOWARN(-Wdeprecated-volatile,
       case 4:
 #if defined(__gfx906__)
 #endif
-#if defined(__gfx908__) || defined(__gfx1100__)
+#if defined(__gfx908__)
 #endif
-#if defined(__gfx90a__)
+#if defined(__gfx90a__) || defined(__gfx1100__)
         asm volatile(
             "global_load_dword %0 %1 off glc slc \n"
             "s_waitcnt vmcnt(0)"
@@ -168,9 +168,9 @@ NOWARN(-Wdeprecated-volatile,
       case 8:
 #if defined(__gfx906__)
 #endif
-#if defined(__gfx908__) || defined(__gfx1100__)
+#if defined(__gfx908__)
 #endif
-#if defined(__gfx90a__)
+#if defined(__gfx90a__) || defined(__gfx1100__)
         asm volatile(
             "global_load_dwordx2 %0 %1 off glc slc \n"
             "s_waitcnt vmcnt(0)"
@@ -224,13 +224,17 @@ __device__ __forceinline__ void store_asm(uint8_t* val, uint8_t* dst,
       int16_t val16{*(reinterpret_cast<int16_t*>(val))};
 #if defined(__gfx906__)
 #endif
-#if defined(__gfx908__) || defined(__gfx1100__)
+#if defined(__gfx908__)
 #endif
 #if defined(__gfx90a__)
       asm volatile("flat_store_short %0 %1 glc slc" : : "v"(dst), "v"(val16));
 #endif
 #if defined(__gfx942__) || defined(__gfx950__)
       asm volatile("flat_store_short %0 %1 sc0 sc1" : : "v"(dst), "v"(val16));
+#endif
+#if defined(__gfx1100__)
+      int32_t val32{*(reinterpret_cast<int32_t*>(val))};
+      asm volatile("flat_store_short %0 %1 glc slc" : : "v"(dst), "v"(val32));
 #endif
 #if defined(__gfx1201__)
       asm volatile("flat_store_b16 %0 %1 scope:SCOPE_SYS" : : "v"(dst), "v"(val16));
@@ -241,9 +245,9 @@ __device__ __forceinline__ void store_asm(uint8_t* val, uint8_t* dst,
       int32_t val32{*(reinterpret_cast<int32_t*>(val))};
 #if defined(__gfx906__)
 #endif
-#if defined(__gfx908__) || defined(__gfx1100__)
+#if defined(__gfx908__)
 #endif
-#if defined(__gfx90a__)
+#if defined(__gfx90a__) || defined(__gfx1100__)
       asm volatile("flat_store_dword %0 %1 glc slc" : : "v"(dst), "v"(val32));
 #endif
 #if defined(__gfx942__) || defined(__gfx950__)
@@ -258,9 +262,9 @@ __device__ __forceinline__ void store_asm(uint8_t* val, uint8_t* dst,
       int64_t val64{*(reinterpret_cast<int64_t*>(val))};
 #if defined(__gfx906__)
 #endif
-#if defined(__gfx908__) || defined(__gfx1100__)
+#if defined(__gfx908__)
 #endif
-#if defined(__gfx90a__)
+#if defined(__gfx90a__) || defined(__gfx1100__)
       asm volatile("flat_store_dwordx2 %0 %1 glc slc" : : "v"(dst), "v"(val64));
 #endif
 #if defined(__gfx942__) || defined(__gfx950__)


### PR DESCRIPTION
## Motivation

- reenable gfx1100 support in rocSHMEM. To be merged only after staging completed.
- apply the same fix for gfx1201 for avoiding future breakage

## Technical Details

use the modified version of the flat_store_short assembly instruction as suggested by the compiler team (32bit input value instead of 16bit)

## Test Results

- gfx1100 the same set of tests pass as with the previous version on ROCm 7.0.2
- gfx1201 confirmed that functional tests still pass

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
