### PR TITLE
Functional tests without MPI support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,7 +164,6 @@ if (NOT BUILD_TESTS_ONLY)
     set(HAVE_EXTERNAL_MPI ON)
   else()
     set(HAVE_EXTERNAL_MPI OFF)
-    set(BUILD_FUNCTIONAL_TESTS OFF)
     set(BUILD_UNIT_TESTS OFF)
   endif()
 

--- a/src/gda/backend_gda.cpp
+++ b/src/gda/backend_gda.cpp
@@ -658,10 +658,9 @@ int GDABackend::backend_can_run() {
   if (requested == GDAProvider::UNSET || requested == GDAProvider::BNXT) {
     handle = bnxt_dv_dlopen();
     if (handle) {
+      auto ret = has_active_ib_interface(GDAProvider::BNXT);
       dlclose(handle);
-      if (has_active_ib_interface(GDAProvider::BNXT)) {
-        return ROCSHMEM_SUCCESS;
-      }
+      if (ret) return ROCSHMEM_SUCCESS;
       DPRINTF("BNXT DV library found but no active InfiniBand interface available\n");
     }
   }
@@ -672,10 +671,9 @@ int GDABackend::backend_can_run() {
   if (requested == GDAProvider::UNSET || requested == GDAProvider::IONIC) {
     handle = ionic_dv_dlopen();
     if (handle) {
+      auto ret = has_active_ib_interface(GDAProvider::IONIC);
       dlclose(handle);
-      if (has_active_ib_interface(GDAProvider::IONIC)) {
-        return ROCSHMEM_SUCCESS;
-      }
+      if (ret) return ROCSHMEM_SUCCESS;
       DPRINTF("IONIC DV library found but no active InfiniBand interface available\n");
     }
   }
@@ -686,10 +684,9 @@ int GDABackend::backend_can_run() {
   if (requested == GDAProvider::UNSET || requested == GDAProvider::MLX5) {
     handle = mlx5_dv_dlopen();
     if (handle) {
+      auto ret = has_active_ib_interface(GDAProvider::MLX5);
       dlclose(handle);
-      if (has_active_ib_interface(GDAProvider::MLX5)) {
-        return ROCSHMEM_SUCCESS;
-      }
+      if (ret) return ROCSHMEM_SUCCESS;
       DPRINTF("MLX5 DV library found but no active InfiniBand interface available\n");
     }
   }

--- a/src/gda/backend_gda.cpp
+++ b/src/gda/backend_gda.cpp
@@ -29,6 +29,7 @@
 #include <cassert>
 
 #include "backend_gda.hpp"
+#include "ibv_wrapper.hpp"
 #include "envvar.hpp"
 #include "gda_team.hpp"
 #include "mpi_instance.hpp"
@@ -648,6 +649,9 @@ bool GDABackend::has_active_ib_interface(GDAProvider provider) {
 int GDABackend::backend_can_run() {
   void *handle{nullptr};
   GDAProvider requested = requested_provider();
+
+  /* Basic verbs? */
+  if (!ibv.is_initialized) return ROCSHMEM_ERROR;
 
   /* Try opening bnxt DV libraries */
 #if defined(GDA_BNXT)

--- a/src/gda/backend_gda.hpp
+++ b/src/gda/backend_gda.hpp
@@ -26,6 +26,7 @@
 #define LIBRARY_SRC_GDA_BACKEND_HPP_
 
 #include <dlfcn.h>
+#include <infiniband/verbs.h>
 
 #include "backend_bc.hpp"
 #include "containers/free_list_impl.hpp"
@@ -36,7 +37,6 @@
 #include "queue_pair.hpp"
 #include "bootstrap/bootstrap.hpp"
 #include "debug_gda.hpp"
-#include "ibv_wrapper.hpp"
 #include "gda/ionic/provider_gda_ionic.hpp"
 #include "gda/bnxt/provider_gda_bnxt.hpp"
 #include "gda/mlx5/provider_gda_mlx5.hpp"

--- a/src/gda/ibv_wrapper.cpp
+++ b/src/gda/ibv_wrapper.cpp
@@ -42,19 +42,21 @@ IBVWrapper::IBVWrapper() {
     ibv_handle = dlopen("/usr/lib/x86_64-linux-gnu/libibverbs.so", RTLD_NOW);
 
     if (!ibv_handle) {
-      DPRINTF("Could not open libibverbs. Returning\n");
-      exit(1);
+      DPRINTF("Could not open libibverbs. Disabled.\n");
+      return;
     }
   }
 
   err = init_function_table();
   if (err != ROCSHMEM_SUCCESS) {
-    DPRINTF("Could not construct InfiniBand Verbs function table \n");
-    exit(1);
+    DPRINTF("Could not construct InfiniBand Verbs function table. Disabled.\n");
+    return;
   }
+  is_initialized = true;
 }
 
 IBVWrapper::~IBVWrapper() {
+  is_initialized = false;
   if (ibv_handle != nullptr) {
     dlclose(ibv_handle);
   }

--- a/src/gda/ibv_wrapper.hpp
+++ b/src/gda/ibv_wrapper.hpp
@@ -38,6 +38,8 @@ class IBVWrapper {
     explicit IBVWrapper();
     virtual ~IBVWrapper();
 
+    bool is_initialized{false};
+
     struct ibv_device** get_device_list(int *num_devices);
     void free_device_list(struct ibv_device **list);
 

--- a/src/mpi_instance.cpp
+++ b/src/mpi_instance.cpp
@@ -138,6 +138,9 @@ void MPIInstance::mpilib_dl_close() {
 
 MPIInstance::MPIInstance(MPI_Comm comm) {
   int is_init{0};
+
+  assert (nullptr != mpilib_handle_);
+
   mpilib_ftable_.Initialized(&is_init);
 
   if (!is_init) {

--- a/src/reverse_offload/backend_ro.cpp
+++ b/src/reverse_offload/backend_ro.cpp
@@ -131,6 +131,12 @@ ROBackend::ROBackend(MPI_Comm comm)
   *done_init = 1;
 }
 
+/* Currently we only check whether we can dlopen an MPI library.
+ */
+int ROBackend::backend_can_run() {
+  return MPIInstance::mpilib_dl_init();
+}
+
 void ROBackend::setup_ctxs() {
   CHECK_HIP(hipMalloc(&ctx_array, sizeof(ROContext) * envvar::max_num_contexts));
   for (size_t i = 0; i < envvar::max_num_contexts; i++) {

--- a/src/reverse_offload/backend_ro.cpp
+++ b/src/reverse_offload/backend_ro.cpp
@@ -33,6 +33,7 @@
 #include <cstdlib>
 #include <memory>
 #include <thread>  // NOLINT
+#include <dlfcn.h>
 
 #include "rocshmem/rocshmem.hpp"
 #include "atomic_return.hpp"
@@ -134,7 +135,13 @@ ROBackend::ROBackend(MPI_Comm comm)
 /* Currently we only check whether we can dlopen an MPI library.
  */
 int ROBackend::backend_can_run() {
-  return MPIInstance::mpilib_dl_init();
+  auto handle = dlopen("libmpi.so", RTLD_NOW);
+  if (!handle) {
+    printf("Could not open libmpi.so. Returning\n");
+    return ROCSHMEM_ERROR;
+  }
+  dlclose(handle);
+  return ROCSHMEM_SUCCESS;
 }
 
 void ROBackend::setup_ctxs() {

--- a/src/reverse_offload/backend_ro.cpp
+++ b/src/reverse_offload/backend_ro.cpp
@@ -135,11 +135,12 @@ ROBackend::ROBackend(MPI_Comm comm)
 /* Currently we only check whether we can dlopen an MPI library.
  */
 int ROBackend::backend_can_run() {
-  auto handle = dlopen("libmpi.so", RTLD_NOW);
+  auto handle = dlopen("libmpi.so", RTLD_LAZY);
   if (!handle) {
     printf("Could not open libmpi.so. Returning\n");
     return ROCSHMEM_ERROR;
   }
+  //TODO dlsym MPI_Get_library_version and verify compat when HAVE_EXTERNAL_MPI is undef
   dlclose(handle);
   return ROCSHMEM_SUCCESS;
 }

--- a/src/reverse_offload/backend_ro.hpp
+++ b/src/reverse_offload/backend_ro.hpp
@@ -73,6 +73,14 @@ class ROBackend : public Backend {
   virtual ~ROBackend();
 
   /**
+   * @brief Verify whether RO Backend could run
+   *
+   * @return ROSCHMEM_SUCCESS if RO backend can most likely be used
+   *         ROCSHMEM_ERROR otherwise
+   */
+  static int backend_can_run(void);
+
+  /**
    * @brief Abort the application.
    *
    * @param[in] status Exit code.

--- a/src/rocshmem.cpp
+++ b/src/rocshmem.cpp
@@ -107,7 +107,7 @@ static BackendType select_backend_type() {
     DPRINTF("GDABackend::backend_can_run returned success\n");
     return BackendType::GDA_BACKEND;
   }
-  if (MPIInstance::mpilib_dl_init() == ROCSHMEM_SUCCESS) {
+  if (ROBackend::backend_can_run() == ROCSHMEM_SUCCESS) {
     DPRINTF("MPIInstance could dl_init MPI library\n");
     return BackendType::RO_BACKEND;
   }
@@ -156,7 +156,7 @@ static BackendType select_backend_type() {
   backend = new (backend) GDABackend(comm);
 #elif defined(USE_RO)
   if (ret != ROCSHMEM_SUCCESS) {
-    printf("Could not initialize MPI library. RO conduit requires MPI library to be loaded at runtime. Aborting\n");
+    printf("Could not initialize MPI library. RO conduit requires MPI library to be loaded at runtime. Aborting.\n");
     abort();
   }
   CHECK_HIP(hipHostMalloc(&backend, sizeof(ROBackend)));
@@ -167,7 +167,8 @@ static BackendType select_backend_type() {
 #endif
 
   if (!backend) {
-    abort();
+    printf("No Backend could be initialized! Aborting.\n");
+    exit(1);
   }
 }
 
@@ -177,10 +178,10 @@ static BackendType select_backend_type() {
 
   int ret;
   ret = MPIInstance::mpilib_dl_init();
-  if (ret == ROCSHMEM_SUCCESS) {
-    printf("Could not initialize MPI library. This initialization method of "
-           "rocSHMEM requires MPI library to be loaded at runtime. Aborting\n");
-    abort();
+  if (ret != ROCSHMEM_SUCCESS) {
+    fprintf(stderr, "Could not initialize MPI library. This initialization method of "
+            "rocSHMEM requires MPI library to be loaded at runtime. Aborting.\n");
+    exit(1);
   }
   mpilib_ftable_.Initialized(&initialized);
 
@@ -194,10 +195,10 @@ static BackendType select_backend_type() {
     if (world_size != nranks) {
       // This solution will require MPI_Sessions. This is planned for the
       // future, but is not supported in the current version.
-      fprintf (stderr, "Unsupported configuration to initialize rocSHMEM. Please "
-               "initialize the MPI library using MPI_Init first, if you want to "
-               "initialize rocSHMEM with a subset of the processes\n");
-      abort();
+      fprintf(stderr, "Unsupported configuration to initialize rocSHMEM. Please "
+              "initialize the MPI library using MPI_Init first, if you want to "
+              "initialize rocSHMEM with a subset of the processes\n");
+      exit(1);
     }
   } else {
     mpilib_ftable_.Comm_size (MPI_COMM_WORLD, &world_size);
@@ -254,9 +255,7 @@ static BackendType select_backend_type() {
   case BackendType::RO_BACKEND:
     /* Not sure whether this is a valid configuration. Will leave it in for now */
     DPRINTF("Initializing RO backend with TCP bootstrapping\n");
-    mpi_instance = new MPIInstance(MPI_COMM_WORLD);
-    CHECK_HIP(hipHostMalloc(&backend, sizeof(ROBackend)));
-    backend = new (backend) ROBackend(MPI_COMM_WORLD);
+    library_init_subcomm(bootstr, bootstr->getNranks(), bootstr->getRank());
     break;
   case BackendType::IPC_BACKEND:
     DPRINTF("Initializing IPC backend with TCP bootstrapping\n");
@@ -269,22 +268,15 @@ static BackendType select_backend_type() {
   backend = new (backend) GDABackend(bootstrap);
 #elif defined(USE_RO)
   /* Not sure whether this is a valid configuration. Will leave it in for now */
-  int ret;
-  ret = MPIInstance::mpilib_dl_init();
-  if (ret != MPI_SUCCESS) {
-    printf("RO Backend requires MPI library to be initialized, even when using uniqueId initializations!\n");
-    abort();
-  }
-  mpi_instance = new MPIInstance(MPI_COMM_WORLD);
-  CHECK_HIP(hipHostMalloc(&backend, sizeof(ROBackend)));
-  backend = new (backend) ROBackend(MPI_COMM_WORLD);
+  library_init_subcomm(bootstr, bootstr->getNranks(), bootstr->getRank());
 #elif defined(USE_IPC)
   CHECK_HIP(hipHostMalloc(&backend, sizeof(IPCBackend)));
   backend = new (backend) IPCBackend(bootstrap);
 #endif
 
   if (!backend) {
-    abort();
+    printf("No Backend could be initialized! Aborting.\n");
+    exit(1);
   }
 }
 

--- a/src/rocshmem.cpp
+++ b/src/rocshmem.cpp
@@ -254,7 +254,6 @@ static BackendType select_backend_type() {
     backend = new (backend) GDABackend(bootstrap);
     break;
   case BackendType::RO_BACKEND:
-    /* Not sure whether this is a valid configuration. Will leave it in for now */
     DPRINTF("Initializing RO backend with TCP bootstrapping\n");
     library_init_subcomm(bootstr, bootstr->getNranks(), bootstr->getRank());
     break;
@@ -268,7 +267,6 @@ static BackendType select_backend_type() {
   CHECK_HIP(hipHostMalloc(&backend, sizeof(GDABackend)));
   backend = new (backend) GDABackend(bootstrap);
 #elif defined(USE_RO)
-  /* Not sure whether this is a valid configuration. Will leave it in for now */
   library_init_subcomm(bootstr, bootstr->getNranks(), bootstr->getRank());
 #elif defined(USE_IPC)
   CHECK_HIP(hipHostMalloc(&backend, sizeof(IPCBackend)));
@@ -462,7 +460,8 @@ __host__ void * rocshmem_ptr(const void * dest, int pe){
   if (bootstr != nullptr)
     delete bootstr;
 
-  MPIInstance::mpilib_dl_close();
+  //TODO This crashes
+  //MPIInstance::mpilib_dl_close();
 }
 
 __host__ void rocshmem_query_thread(int *provided) {

--- a/src/rocshmem.cpp
+++ b/src/rocshmem.cpp
@@ -130,6 +130,11 @@ static BackendType select_backend_type() {
 
   int ret;
   ret = MPIInstance::mpilib_dl_init();
+  if (ret != ROCSHMEM_SUCCESS) {
+    fprintf(stderr, "Could not initialize MPI library. This initialization method of "
+            "rocSHMEM requires MPI library to be loaded at runtime. Aborting.\n");
+    exit(1);
+  }
   mpi_instance = new MPIInstance(comm);
 
 #if defined(USE_GDA) && defined(USE_RO) && defined(USE_IPC)
@@ -155,10 +160,6 @@ static BackendType select_backend_type() {
   CHECK_HIP(hipHostMalloc(&backend, sizeof(GDABackend)));
   backend = new (backend) GDABackend(comm);
 #elif defined(USE_RO)
-  if (ret != ROCSHMEM_SUCCESS) {
-    printf("Could not initialize MPI library. RO conduit requires MPI library to be loaded at runtime. Aborting.\n");
-    abort();
-  }
   CHECK_HIP(hipHostMalloc(&backend, sizeof(ROBackend)));
   backend = new (backend) ROBackend(comm);
 #elif defined(USE_IPC)
@@ -185,7 +186,9 @@ static BackendType select_backend_type() {
   }
   mpilib_ftable_.Initialized(&initialized);
 
-  if (!initialized) {
+  if (initialized) {
+    mpilib_ftable_.Comm_size (MPI_COMM_WORLD, &world_size);
+  } else {
     // This is an Open MPI specific solution to retrieve the number of
     // processes that have been started, value can be checked before MPI_Init
     char *value = getenv("OMPI_COMM_WORLD_SIZE");
@@ -200,8 +203,6 @@ static BackendType select_backend_type() {
               "initialize rocSHMEM with a subset of the processes\n");
       exit(1);
     }
-  } else {
-    mpilib_ftable_.Comm_size (MPI_COMM_WORLD, &world_size);
   }
 
   if (world_size == nranks) {
@@ -310,7 +311,7 @@ static BackendType select_backend_type() {
     if (envvar::uniqueid_with_mpi) {
       library_init_subcomm(bootstr, attr->nranks, attr->rank);
     } else {
-      library_init (bootstr);
+      library_init(bootstr);
     }
   }
 
@@ -359,7 +360,12 @@ static BackendType select_backend_type() {
 #endif
 
 [[maybe_unused]] __host__ void rocshmem_init() {
-  MPIInstance::mpilib_dl_init();
+  auto ret = MPIInstance::mpilib_dl_init();
+  if (ret != ROCSHMEM_SUCCESS) {
+    fprintf(stderr, "Could not initialize MPI library. This initialization method of "
+            "rocSHMEM requires MPI library to be loaded at runtime. Aborting.\n");
+    exit(1);
+  }
   library_init(MPI_COMM_WORLD);
 }
 
@@ -450,11 +456,13 @@ __host__ void * rocshmem_ptr(const void * dest, int pe){
   backend->~Backend();
   CHECK_HIP(hipHostFree(backend));
 
-  if (bootstr == nullptr)
+  if (mpi_instance != nullptr)
     delete mpi_instance;
 
   if (bootstr != nullptr)
     delete bootstr;
+
+  MPIInstance::mpilib_dl_close();
 }
 
 __host__ void rocshmem_query_thread(int *provided) {

--- a/tests/functional_tests/test_driver.cpp
+++ b/tests/functional_tests/test_driver.cpp
@@ -172,6 +172,9 @@ int main(int argc, char *argv[]) {
     char key[] = "rocshmem-uuid";
     pmix_bcast(&uid, sizeof(rocshmem_uniqueid_t), key, 0);
 
+    // Close PMIx before potentially doing MPI_Init inside rocshmem_init
+    PMIx_Finalize(NULL, 0);
+
     ret = rocshmem_set_attr_uniqueid_args(rank, nranks, &uid, &attr);
     if (ret != ROCSHMEM_SUCCESS) {
       std::cout << rank << ": Error in rocshmem_set_attr_uniqueid_args. Aborting.\n";
@@ -223,12 +226,6 @@ int main(int argc, char *argv[]) {
    * with the init function above.
    */
   rocshmem_finalize();
-
-#ifdef HAVE_PMIX
-  if (test_uuid) {
-    PMIx_Finalize(NULL, 0);
-  }
-#endif
 
   return 0;
 }


### PR DESCRIPTION
## Motivation

* Enable building and running functional tests without MPI 
* build without an external MPI
* run without loading libmpi or calling MPI_INIT
* run RO with ROCSHMEM_TEST_UUID=1 initialization
* run TEST_UUID with GDA device-interface and RO host-interface

## Technical Details

* PMIx must be finalized before calling MPI_Init (presumably a defect in Open MPI, should be possible to have two PMIx clients registered at the same time).
* RO initialization from bootstrap initialization testing found bugs and issues
* Adding RO backend_can_run to check if loading MPI is possible
* bugfix: if libibverbs.so is not found we should not crash, just GDA backend_can_run return false.
* bugfix: we cannot unload mlx5_dv (and similar) before we run ibv_device_list as that leaves libibverbs in a broken state. 

## Test Plan

Tested on Banff-RAD in the above configurations. 

* RO w/o EXTERNAL_MPI with rocshmem_init works
* GDA w/o EXTERNAL_MPI with rocshmem_init works
* RO w/o EXTERNAL_MPI with rocshmem_init_attr works
* GDA w/o EXTERNAL_MPI with rocshmem_init_attr works 