### PR TITLE
Add IBGDA backend flag to enable bitcode generation

### DIFF
--- a/src/rocshmem_gpu.cpp
+++ b/src/rocshmem_gpu.cpp
@@ -53,7 +53,7 @@
 
 #if defined(USE_GDA)
 #if defined (ENABLE_IBGDA_BITCODE)
-  #include "gda/backend_gda.hpp"
+#  include "gda/backend_gda.hpp"
 #endif
 #include "gda/context_gda_tmpl_device.hpp"
 #endif

--- a/src/rocshmem_gpu.cpp
+++ b/src/rocshmem_gpu.cpp
@@ -52,6 +52,9 @@
 #include "util.hpp"
 
 #if defined(USE_GDA)
+#if defined (ENABLE_IBGDA_BITCODE)
+  #include "gda/backend_gda.hpp"
+#endif
 #include "gda/context_gda_tmpl_device.hpp"
 #endif
 #if defined(USE_RO)
@@ -76,6 +79,8 @@ __constant__ Backend *device_backend_proxy;
 
 #if defined(ENABLE_IPC_BITCODE)
   typedef IPCContext ContextTy;
+#elif defined(ENABLE_IBGDA_BITCODE)
+  typedef GDAContext ContextTy;
 #else
   typedef Context ContextTy;
 #endif


### PR DESCRIPTION
## Motivation
This is follow-up change to #217 to enable device bitcode generation for GDA backend.

## Technical Details

This is required to explicitly compile GDAContext class device APIs when GDA backend is used for multi-node execution. 

## Test Plan

Tested as part of triton distributed project work

## Test Result

Does not affect existing rocSHMEM tests.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
