### PR TITLE
Reenable building test-only with external MPI

### DIFF
--- a/cmake/setup_project.cmake
+++ b/cmake/setup_project.cmake
@@ -29,7 +29,7 @@ set(CMAKE_BUILD_TYPE "Release" CACHE STRING
       "build type: Release, Debug, RelWithDebInfo, MinSizeRel")
 
 ###############################################################################
-# GLOBAL COMPILE FLAGS
+# DEPENDENCIES
 ###############################################################################
 
 # Try to establish ROCM_PATH (for find_package)
@@ -70,6 +70,10 @@ endforeach()
 if (NOT DEFINED CMAKE_CXX_COMPILER)
   find_program(CMAKE_CXX_COMPILER hipcc PATHS /opt/rocm)
 endif()
+
+###############################################################################
+# GLOBAL COMPILE FLAGS
+###############################################################################
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -29,6 +29,7 @@ cmake_minimum_required(VERSION 3.16.3 FATAL_ERROR)
 include(${CMAKE_SOURCE_DIR}/cmake/setup_project.cmake)
 project(rocshmem_examples VERSION 1.0.0 LANGUAGES CXX)
 
+find_package(MPI)
 find_package(hip REQUIRED PATHS /opt/rocm)
 if (NOT TARGET roc::rocshmem)
   find_package(rocshmem REQUIRED PATHS /opt/rocm)
@@ -45,7 +46,7 @@ set(EXAMPLE_SOURCES
   rocshmem_put_signal_test.cc
 )
 
-if (HAVE_EXTERNAL_MPI)
+if (MPI_CXX_FOUND)
   list(APPEND EXAMPLE_SOURCES
     rocshmem_init_attr_test.cc)
 endif()
@@ -58,7 +59,7 @@ foreach(SOURCE_FILE IN LISTS EXAMPLE_SOURCES)
   target_link_libraries(
     ${EXECUTABLE_NAME}
     PRIVATE
-      $<TARGET_NAME_IF_EXISTS:MPI::MPI_CXX>
       roc::rocshmem
+      $<TARGET_NAME_IF_EXISTS:MPI::MPI_CXX>
   )
 endforeach()

--- a/src/mpi_instance.hpp
+++ b/src/mpi_instance.hpp
@@ -25,8 +25,8 @@
 #ifndef LIBRARY_SRC_MPI_INSTANCE_HPP_
 #define LIBRARY_SRC_MPI_INSTANCE_HPP_
 
-#include <rocshmem/rocshmem_config.h>
-#include <rocshmem/rocshmem_mpi.hpp>
+#include "rocshmem/rocshmem_config.h"
+#include "rocshmem/rocshmem_mpi.hpp"
 #include <memory>
 
 /**

--- a/tests/functional_tests/CMakeLists.txt
+++ b/tests/functional_tests/CMakeLists.txt
@@ -72,14 +72,17 @@ target_sources(
 # ROCSHMEM
 ###############################################################################
 if (BUILD_TESTS_ONLY)
-  #TODO check that build_test_only still works with external-mpi
+  #TODO these find_packages should be performed as-needed in rocshmem-config.cmake
+  find_package(hip REQUIRED PATHS /opt/rocm)
+  find_package(MPI)
+  find_package(Threads REQUIRED)
   find_package(rocshmem REQUIRED PATHS /opt/rocm)
 
   target_include_directories(
     ${PROJECT_NAME}
     PRIVATE
-      $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/..>
       $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}>
+      $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../src>
   )
 endif()
 
@@ -88,12 +91,13 @@ find_package(PMIx)
 target_compile_definitions(
   ${PROJECT_NAME}
   PRIVATE
-    $<$<BOOL:${PMIx_FOUND}>:HAVE_PMIX=1>
+    $<$<TARGET_EXISTS:PMIx::pmix>:HAVE_PMIX=1>
 )
 
 target_link_libraries(
   ${PROJECT_NAME}
   PRIVATE
     roc::rocshmem
-    $<$<BOOL:${PMIx_FOUND}>:PMIx::pmix>
+    $<TARGET_NAME_IF_EXISTS:MPI::MPI_CXX>
+    $<TARGET_NAME_IF_EXISTS:PMIx::pmix>
 )


### PR DESCRIPTION
## Motivation

When building test-only with rocshmem configuration 'external MPI' the build stage of the testers would not find dependent packages as declared by the INTERFACE of rocshmem.

## Technical Details

rocshmem-config.cmake would add MPI::MPI_CXX and other dependencies to the library interface when built with external MPI. The dependee must do a find_package for these dependencies.

## Test Plan

* [x] Can compile with rocshmem-dev (with EXTERNAL_MPI set)
* [x] Can compile with devel (no EXTERNAL MPI set)