### PR TITLE
gda/ro: validate and exit cleanly when forced GDA config is invalid

### DIFF
--- a/src/rocshmem.cpp
+++ b/src/rocshmem.cpp
@@ -93,6 +93,12 @@ static BackendType select_backend_type() {
   if (!envstr.empty()) {
     DPRINTF("Found environment variable ROCSHMEM_BACKEND, value is %s\n", envstr.c_str());
     if (envstr.find("gda") != std::string::npos) {
+      if (GDABackend::backend_can_run() != ROCSHMEM_SUCCESS) {
+        fprintf(stderr, "Error: ROCSHMEM_BACKEND=gda requested but GDA backend cannot run.\n"
+                        "No active RDMA interface found for the requested provider.\n"
+                        "Check that the correct NIC hardware is present and the link is active.\n");
+        exit(1);
+      }
       return BackendType::GDA_BACKEND;
     }
     if (envstr.find("ro") != std::string::npos) {

--- a/src/rocshmem.cpp
+++ b/src/rocshmem.cpp
@@ -102,6 +102,12 @@ static BackendType select_backend_type() {
       return BackendType::GDA_BACKEND;
     }
     if (envstr.find("ro") != std::string::npos) {
+      if (ROBackend::backend_can_run() != ROCSHMEM_SUCCESS) {
+        fprintf(stderr, "Error: ROCSHMEM_BACKEND=ro requested but RO backend cannot run.\n"
+                        "MPI library could not be loaded.\n"
+                        "Check that MPI is properly installed and accessible.\n");
+        exit(1);
+      }
       return BackendType::RO_BACKEND;
     }
     if (envstr.find("ipc") != std::string::npos) {


### PR DESCRIPTION
## Motivation

AIROCSHMEM-201

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

When user forces GDA backend via ROCSHMEM_BACKEND=gda environment variable, validate that the backend can actually run before proceeding. Previously, this would skip validation and crash later during initialization with errors like 'ibv_alloc_parent_domain: Operation not supported'.

Now exits cleanly with a helpful error message when forcing invalid
configurations like ROCSHMEM_BACKEND=gda with ROCSHMEM_GDA_PROVIDER=mlx5
on a system without MLX5 hardware.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

Manual test:
mpirun -x ROCSHMEM_BACKEND=gda  -x ROCSHMEM_DISABLE_MIXED_IPC=1 -x ROCSHMEM_GDA_PROVIDER=mlx5 --oversubscribe -np 2 examples/rocshmem_alltoall_test
```
Found environment variable ROCSHMEM_BACKEND, value is gda
Found environment variable ROCSHMEM_GDA_PROVIDER, value is mlx5
Found environment variable ROCSHMEM_BACKEND, value is gda
Found environment variable ROCSHMEM_GDA_PROVIDER, value is mlx5
Skipping device bnxt_re0 with vendor_id=0x14e4 (not MLX5/Mellanox)
Skipping device bnxt_re1 with vendor_id=0x14e4 (not MLX5/Mellanox)
Skipping device bnxt_re2 with vendor_id=0x14e4 (not MLX5/Mellanox)
Skipping device bnxt_re3 with vendor_id=0x14e4 (not MLX5/Mellanox)
Skipping device bnxt_re4 with vendor_id=0x14e4 (not MLX5/Mellanox)
Skipping device bnxt_re5 with vendor_id=0x14e4 (not MLX5/Mellanox)
Skipping device bnxt_re0 with vendor_id=0x14e4 (not MLX5/Mellanox)
Skipping device bnxt_re6 with vendor_id=0x14e4 (not MLX5/Mellanox)
Skipping device bnxt_re7 with vendor_id=0x14e4 (not MLX5/Mellanox)
Skipping device bnxt_re1 with vendor_id=0x14e4 (not MLX5/Mellanox)
Skipping device bnxt_re2 with vendor_id=0x14e4 (not MLX5/Mellanox)
Skipping device bnxt_re8 with vendor_id=0x14e4 (not MLX5/Mellanox)
Skipping device bnxt_re3 with vendor_id=0x14e4 (not MLX5/Mellanox)
Skipping device bnxt_re9 with vendor_id=0x14e4 (not MLX5/Mellanox)
No active InfiniBand ports found on any device
Skipping device bnxt_re4 with vendor_id=0x14e4 (not MLX5/Mellanox)
MLX5 DV library found but no active InfiniBand interface available
Error: ROCSHMEM_BACKEND=gda requested but GDA backend cannot run.
No active RDMA interface found for the requested provider.
Check that the correct NIC hardware is present and the link is active.
Skipping device bnxt_re5 with vendor_id=0x14e4 (not MLX5/Mellanox)
Skipping device bnxt_re6 with vendor_id=0x14e4 (not MLX5/Mellanox)
Skipping device bnxt_re7 with vendor_id=0x14e4 (not MLX5/Mellanox)
Skipping device bnxt_re8 with vendor_id=0x14e4 (not MLX5/Mellanox)
Skipping device bnxt_re9 with vendor_id=0x14e4 (not MLX5/Mellanox)
No active InfiniBand ports found on any device
MLX5 DV library found but no active InfiniBand interface available
Error: ROCSHMEM_BACKEND=gda requested but GDA backend cannot run.
No active RDMA interface found for the requested provider.
Check that the correct NIC hardware is present and the link is active.
--------------------------------------------------------------------------
Primary job  terminated normally, but 1 process returned
a non-zero exit code. Per user-direction, the job has been aborted.
--------------------------------------------------------------------------
--------------------------------------------------------------------------
mpirun detected that one or more processes exited with non-zero status, thus causing
the job to be terminated. The first process to do so was:

  Process name: [[33609,1],0]
  Exit code:    1
--------------------------------------------------------------------------
```

Also I've tested that forced RO backend terminates gracefully if there is no MPI available
```
vkutovoi@dell300x-ccs-aus-k13-03:~/rocSHMEM/build$ # Test with IPC backend (avoids GDA complexity)
RANK=0 NRANKS=2 ROCSHMEM_BACKEND=ro ./examples/rocshmem_alltoall_tcp_test &
sleep 1
RANK=1 NRANKS=2 ROCSHMEM_BACKEND=ro ./examples/rocshmem_alltoall_tcp_test
wait
[1] 3700759
Rank 0/2 starting (TCP bootstrap)
Rank 0 using GPU 0
Found interface lo:127.0.0.1<0>
Found interface eno8303:10.194.129.126<0>
TcpBootstrap : Using eno8303:10.194.129.126<0>Rank 0: wrote unique ID to /tmp/rocshmem_uid_3700236
Found interface lo:127.0.0.1<0>
Found interface eno8303:10.194.129.126<0>
TcpBootstrap : Using eno8303:10.194.129.126<0>Listening on socket 10.194.129.126<51291>
rank 0 nranks 2 - connecting to 10.194.129.126<51291>
establishConnections: rank 0 nranks 2
Listening on socket 10.194.129.126<39259>
Listening on socket 10.194.129.126<33623>
Connecting to socket 10.194.129.126<51291>
BEGIN bootstrapRoot
Received connect from rank 0 total 1/2
Rank 1/2 starting (TCP bootstrap)
Rank 1 using GPU 1
Rank 1: read unique ID from /tmp/rocshmem_uid_3700236
Found interface lo:127.0.0.1<0>
Found interface eno8303:10.194.129.126<0>
TcpBootstrap : Using eno8303:10.194.129.126<0>rank 1 nranks 2 - connecting to 10.194.129.126<51291>
establishConnections: rank 1 nranks 2
Listening on socket 10.194.129.126<54403>
Listening on socket 10.194.129.126<35437>
Connecting to socket 10.194.129.126<51291>
Received connect from rank 1 total 2/2
COLLECTED ALL 2 HANDLES
Connecting to socket 10.194.129.126<33623>
Connecting to socket 10.194.129.126<35437>
DONE bootstrapRoot
Connecting to socket 10.194.129.126<54403>
Connecting to socket 10.194.129.126<39259>
allGather: rank 1 nranks 2 size 28
allGather: rank 0 nranks 2 size 28
allGather: rank 1 nranks 2 size 28 - DONE
allGather: rank 0 nranks 2 size 28 - DONE
rank 1 nranks 2 - DONE
rank 0 nranks 2 - DONE
Found environment variable ROCSHMEM_BACKEND, value is ro
Found environment variable ROCSHMEM_BACKEND, value is ro
Could not open libmpi.so. Returning
Could not open libmpi.so. Returning
Error: ROCSHMEM_BACKEND=ro requested but RO backend cannot run.
MPI library could not be loaded.
Check that MPI is properly installed and accessible.
Error: ROCSHMEM_BACKEND=ro requested but RO backend cannot run.
MPI library could not be loaded.
Check that MPI is properly installed and accessible.
[1]+  Exit 1                  RANK=0 NRANKS=2 ROCSHMEM_BACKEND=ro ./examples/rocshmem_alltoall_tcp_test
```

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
