### PR TITLE
remove cq lock

### DIFF
--- a/src/gda/bnxt/provider_gda_bnxt.hpp
+++ b/src/gda/bnxt/provider_gda_bnxt.hpp
@@ -39,10 +39,6 @@ struct bnxt_device_wq {
   uint32_t tail;
   uint32_t flags;
   uint32_t id;
-
-  uint32_t lock;
-
-  uint32_t db_cnt {0};
 } __attribute__((packed));
 
 struct bnxt_device_cq : public bnxt_device_wq {
@@ -56,6 +52,7 @@ struct bnxt_device_sq : public bnxt_device_wq {
   uint32_t msn_tbl_sz;
   uint32_t psn_sz_log2;
   uint64_t mtu;
+  uint32_t lock;
 } __attribute__((packed));
 
 struct bnxt_host_cq {

--- a/src/gda/bnxt/queue_pair_bnxt.cpp
+++ b/src/gda/bnxt/queue_pair_bnxt.cpp
@@ -177,8 +177,6 @@ __device__ void QueuePair::poll_cq_until(uint32_t requested_available_slots) {
 
   sq_depth = sq.depth;
 
-  aquire_lock(&cq.lock);
-
   do {
     cqe = (struct bnxt_re_req_cqe *) cq.buf;
 
@@ -197,8 +195,6 @@ __device__ void QueuePair::poll_cq_until(uint32_t requested_available_slots) {
     consumed_slots  = (sq_tail - sq_head + sq_depth) % sq_depth;
     available_slots = sq_depth - consumed_slots;
   } while (available_slots < requested_available_slots);
-
-  release_lock(&cq.lock);
 }
 
 __device__ void QueuePair::bnxt_quiet() {


### PR DESCRIPTION
## Motivation

PR #327 indicated that when using collapsed CQE mode, we do not need locks around the CQ

## Technical Details

Removed locks from the bnxt code path

## Test Plan

- [x] rocSHMEM functional tests
- [x] DeepEP validation

Some minor performance improvement was noted in both tests