### PR TITLE
[GDA/mlx5] CQ collapsing

### DIFF
--- a/src/gda/backend_gda.cpp
+++ b/src/gda/backend_gda.cpp
@@ -1282,6 +1282,19 @@ void GDABackend::create_cqs(int cqe) {
   cq_attr.comp_mask     = IBV_CQ_INIT_ATTR_MASK_PD;
   cq_attr.parent_domain = pd_parent;
 
+  /* enable mlx5 CQ collapsing by setting CQ length to 1 and enabling CQ overrun ignore:
+   *  - mlx5 driver sets mlx5_ifc_cqc_bits::oi bit when IBV_CREATE_CQ_ATTR_IGNORE_OVERRUN is set
+   *    this has the hardware ignore CQ overruns; CQ consumer counter doorbells should not be rung
+   *  - see Mellanox Adapters Programmer’s Reference Manual Rev 0.40, §7.12.8, Tables 75-76
+   *    and linux/include/linux/mlx5/mlx5_ifc.h for Completion Queue Context definition
+   *  - see also rdma-core/libibverbs/cmd_cq.c and linux/drivers/infiniband/hw/mlx5/cq.c
+   *    for how this flag sets the bit */
+  if (gda_provider == GDAProvider::MLX5) {
+    cq_attr.cqe         = 1;
+    cq_attr.comp_mask  |= IBV_CQ_INIT_ATTR_MASK_FLAGS;
+    cq_attr.flags      |= IBV_CREATE_CQ_ATTR_IGNORE_OVERRUN;
+  }
+
   for (int i = 0; i < qps.size(); i++) {
     cq_ex = ibv.create_cq_ex(context, &cq_attr);
     CHECK_NNULL(cq_ex, "ibv_create_cq_ex");
@@ -1309,6 +1322,11 @@ void GDABackend::initialize_gpu_qp(QueuePair* gpu_qp, int conn_num) {
 
 void GDABackend::create_qps(int sq_length) {
   struct ibv_qp_init_attr_ex attr;
+
+  if (gda_provider == GDAProvider::MLX5) {
+    // mlx5 provider can support up to 28B of inline data in a WQE
+    inline_threshold = sizeof(gda_mlx5_wqe_inline_data::data);
+  }
 
   memset(&attr, 0, sizeof(struct ibv_qp_init_attr_ex));
   attr.cap.max_send_wr     = sq_length;

--- a/src/gda/mlx5/backend_gda_mlx5.cpp
+++ b/src/gda/mlx5/backend_gda_mlx5.cpp
@@ -65,10 +65,7 @@ void GDABackend::mlx5_initialize_gpu_qp(QueuePair* gpu_qp, int conn_num) {
    * };
    */
 
-  gpu_qp->cq_buf = reinterpret_cast<mlx5_cqe64*>(cq_out.buf);
-  gpu_qp->cq_cnt = cq_out.cqe_cnt;
-  gpu_qp->cq_log_cnt = log2(cq_out.cqe_cnt);
-  gpu_qp->cq_dbrec = cq_out.dbrec;
+  gpu_qp->mlx5_cq = gda_mlx5_device_cq(reinterpret_cast<mlx5_cqe64*>(cq_out.buf), cq_out.dbrec);
 
   mlx5dv_qp qp_out;
   mlx_obj.qp.in = qps[conn_num];
@@ -103,20 +100,28 @@ void GDABackend::mlx5_initialize_gpu_qp(QueuePair* gpu_qp, int conn_num) {
    * };
    */
 
-  gpu_qp->dbrec = &qp_out.dbrec[1]; // points to two pointers: 0 -> MLX5_REC_DBR, 1 -> MLX5_SND_DBR
-  gpu_qp->sq_buf = reinterpret_cast<uint64_t*>(qp_out.sq.buf);
-  gpu_qp->sq_wqe_cnt = qp_out.sq.wqe_cnt;
+  // The 2 in qp_out.bf.size * 2 below facilitates the switching between blue flame registers
+  int hip_dev_id{-1};
+  CHECK_HIP(hipGetDevice(&hip_dev_id));
+  void* gpu_db_ptr{nullptr};
+  // register both halves of the BlueFlame buffers, hence size is qp_out.bf.size * 2
+  rocm_memory_lock_to_fine_grain(qp_out.bf.reg, qp_out.bf.size * 2, &gpu_db_ptr, hip_dev_id);
+
+  // qp_out.dbrec points to two __be32 values: RQ dbrec at MLX5_RCV_DBR and SQ dbrec at MLX5_SND_DBR
+#if 0
+  gpu_qp->mlx5_sq = gda_mlx5_device_sq{reinterpret_cast<gda_mlx5_wqe*>(qp_out.sq.buf),
+                                       &qp_out.dbrec[MLX5_SND_DBR],
+                                       reinterpret_cast<uint64_t*>(gpu_db_ptr), qp_out.sq.wqe_cnt};
+#endif
+  gpu_qp->mlx5_sq = gda_mlx5_device_sq{reinterpret_cast<gda_mlx5_wqe*>(qp_out.sq.buf),
+                                       &qp_out.dbrec[MLX5_SND_DBR],
+                                       reinterpret_cast<gda_mlx5_doorbell*>(gpu_db_ptr),
+                                       static_cast<uint16_t>(qp_out.sq.wqe_cnt)};
+
   gpu_qp->rkey = htobe32(heap_rkey[conn_num % num_pes]);
   gpu_qp->lkey = htobe32(heap_mr->lkey);
   gpu_qp->qp_num = qps[conn_num]->qp_num;
   gpu_qp->inline_threshold = inline_threshold;
-  // The 2 in qp_out.bf.size * 2 below facilitates the switching between blue flame registers
-
-  int hip_dev_id{-1};
-  CHECK_HIP(hipGetDevice(&hip_dev_id));
-  void* gpu_ptr{nullptr};
-  rocm_memory_lock_to_fine_grain(qp_out.bf.reg, qp_out.bf.size * 2, &gpu_ptr, hip_dev_id);
-  gpu_qp->db.ptr = reinterpret_cast<uint64_t*>(gpu_ptr);
 }
 
 }  // namespace rocshmem

--- a/src/gda/mlx5/provider_gda_mlx5.hpp
+++ b/src/gda/mlx5/provider_gda_mlx5.hpp
@@ -29,13 +29,274 @@ extern "C" {
 #include "gda/mlx5/mlx5dv.h"
 }
 
-typedef union db_reg {
-  uint64_t *ptr;
-  uintptr_t uint;
-} db_reg_t;
+#include "gda/endian.hpp"
+
+namespace rocshmem {
+
+union gda_mlx5_wqe_segment {
+  mlx5_wqe_ctrl_seg     ctrl;
+  mlx5_wqe_raddr_seg    raddr;
+  mlx5_wqe_data_seg     data;
+  mlx5_wqe_inl_data_seg inl_data;
+  mlx5_wqe_atomic_seg   atomic;
+};
+static_assert(sizeof(gda_mlx5_wqe_segment) == 16, "mlx5 WQE segments are 16 bytes");
+
+struct gda_mlx5_wqe_ctrl : public mlx5_wqe_ctrl_seg {
+  __device__ constexpr inline gda_mlx5_wqe_ctrl(
+      uint16_t wqe_idx, uint8_t opcode,
+      uint32_t /* 24-bit */ qpn, uint8_t /* 6-bit */ ds,
+      uint8_t /* [7:5 fm|4|3:2 ce|1 se|0] */ fm_ce_se)
+    : mlx5_wqe_ctrl_seg{
+        .opmod_idx_opcode = endian::to_be<uint32_t>(
+            (static_cast<uint32_t>(wqe_idx) << 8) | static_cast<uint32_t>(opcode)),
+        .qpn_ds = endian::to_be<uint32_t>((qpn << 8) | static_cast<uint32_t>(ds & 0x3F)),
+        .signature = 0,
+        .dci_stream_channel_id = 0,
+        .fm_ce_se = fm_ce_se,
+        .imm = 0,
+      } { }
+} __attribute__((__packed__)) __attribute__((__aligned__(16)));
+
+struct gda_mlx5_wqe_raddr : public mlx5_wqe_raddr_seg {
+  __device__ constexpr inline gda_mlx5_wqe_raddr(uintptr_t raddr, __be32 rkey)
+    : mlx5_wqe_raddr_seg{
+        .raddr = endian::to_be<uint64_t>(raddr),
+        .rkey = rkey,
+        .reserved = 0,
+      } { }
+} __attribute__((__packed__)) __attribute__((__aligned__(16)));
+
+struct gda_mlx5_wqe_data : public mlx5_wqe_data_seg {
+  __device__ constexpr inline gda_mlx5_wqe_data(
+      uintptr_t addr, __be32 lkey, uint32_t byte_count)
+    : mlx5_wqe_data_seg{
+        .byte_count = endian::to_be<uint32_t>(byte_count & ~MLX5_INLINE_SEG),
+        .lkey = lkey,
+        .addr = endian::to_be<uint64_t>(addr),
+      } { }
+} __attribute__((__packed__)) __attribute__((__aligned__(16)));
+
+struct gda_mlx5_wqe_atomic : public mlx5_wqe_atomic_seg {
+  __device__ constexpr inline gda_mlx5_wqe_atomic(
+      uint64_t swap_add, uint64_t compare)
+    : mlx5_wqe_atomic_seg{
+        .swap_add = endian::to_be<uint64_t>(swap_add),
+        .compare = endian::to_be<uint64_t>(compare),
+      } { }
+} __attribute__((__packed__)) __attribute__((__aligned__(16)));
+
+// use up to two segments for mlx5 inline RMA WQEs, since we have space in the 64B WQEBB anyway
+struct gda_mlx5_wqe_inline_data {
+  __be32  byte_count; // only first 10 bits are valid, MSB must be 1
+  uint8_t data[28];   // when byte_count > 12, set ctrl.ds = 4
+
+  __device__ constexpr inline gda_mlx5_wqe_inline_data(
+      uintptr_t addr, uint32_t /* 10-bit */ byte_count)
+    : byte_count{endian::to_be<uint32_t>((byte_count & 0x3FF) | MLX5_INLINE_SEG)}, data{} {
+    memcpy(&this->data[0], reinterpret_cast<void*>(addr), byte_count);
+  }
+} __attribute__((__packed__)) __attribute__((__aligned__(16)));
+static_assert(sizeof(gda_mlx5_wqe_inline_data) == sizeof(gda_mlx5_wqe_segment[2]),
+              "mlx5 RMA WQEs have up to 2 inline data segments");
+
+// RMA WQEs have either a 16B indirect data segment or an inline data segment with up to 28B data
+union gda_mlx5_wqe_rma {
+  gda_mlx5_wqe_data        data;
+  gda_mlx5_wqe_inline_data inline_data;
+
+  __device__ constexpr inline gda_mlx5_wqe_rma(
+      uintptr_t laddr, __be32 lkey, uint32_t byte_count)
+    : data{laddr, lkey, byte_count} { }
+
+  __device__ constexpr inline gda_mlx5_wqe_rma(
+      uintptr_t laddr, uint32_t byte_count)
+    : inline_data{laddr, byte_count} { }
+
+  __device__ static constexpr inline uint8_t ds{3};
+
+  __device__ static constexpr inline uint8_t inline_ds(uint32_t byte_count) {
+    return (byte_count <= 12 ? 3 : 4);
+  }
+
+  __device__ static constexpr inline bool can_inline(
+      uint8_t opcode, uint32_t byte_count, uint32_t inline_threshold) {
+    return (opcode == MLX5_OPCODE_RDMA_WRITE) && (byte_count <= inline_threshold);
+  }
+} __attribute__((__packed__)) __attribute__((__aligned__(16)));
+
+// AMO WQEs have a 16B atomic segment and an (optional?) indirect data segment for fetching atomics
+struct gda_mlx5_wqe_amo {
+  gda_mlx5_wqe_atomic atomic;
+  gda_mlx5_wqe_data   fetch;  // for fetching atomics, set ctrl.ds = 4
+
+  __device__ constexpr inline gda_mlx5_wqe_amo(
+      uint64_t swap_add, uint64_t compare,
+      uintptr_t laddr, __be32 lkey)
+    : atomic{swap_add, compare},
+      fetch{laddr, lkey, 8} { }
+
+  __device__ static constexpr inline uint8_t ds{4};
+} __attribute__((__packed__)) __attribute__((__aligned__(16)));
+
+// WQEs have a 16B control segment, 16B remote address segment, and one or two additional 16B segments
+struct gda_mlx5_wqe {
+  gda_mlx5_wqe_ctrl  ctrl;
+  gda_mlx5_wqe_raddr raddr;
+  union {
+    gda_mlx5_wqe_rma rma;
+    gda_mlx5_wqe_amo amo;
+  };
+
+  // RMA, memory pointer
+  __device__ constexpr inline gda_mlx5_wqe(
+      uint16_t wqe_idx, uint8_t opcode, uint32_t qpn, uint8_t fm_ce_se,
+      uintptr_t raddr, __be32 rkey,
+      uintptr_t laddr, __be32 lkey, uint32_t byte_count)
+    : ctrl{wqe_idx, opcode, qpn, gda_mlx5_wqe_rma::ds, fm_ce_se},
+      raddr{raddr, rkey},
+      rma{laddr, lkey, byte_count} { }
+
+  // RMA, inline
+  __device__ constexpr inline gda_mlx5_wqe(
+      uint16_t wqe_idx, uint8_t opcode, uint32_t qpn, uint8_t fm_ce_se,
+      uintptr_t raddr, __be32 rkey,
+      uintptr_t laddr, uint32_t byte_count)
+    : ctrl{wqe_idx, opcode, qpn, gda_mlx5_wqe_rma::inline_ds(byte_count), fm_ce_se},
+      raddr{raddr, rkey},
+      rma{laddr, byte_count} { }
+
+  // AMO
+  __device__ constexpr inline gda_mlx5_wqe(
+      uint16_t wqe_idx, uint8_t opcode, uint32_t qpn, uint8_t fm_ce_se,
+      uintptr_t raddr, __be32 rkey,
+      uint64_t swap_add, uint64_t compare,
+      uintptr_t laddr, __be32 lkey)
+    : ctrl{wqe_idx, opcode, qpn, gda_mlx5_wqe_amo::ds, fm_ce_se},
+      raddr{raddr, rkey},
+      amo{swap_add, compare, laddr, lkey} { }
+
+private:
+  // return by value to trigger copy elision/prvalue semantics
+  __device__ static constexpr inline gda_mlx5_wqe gda_mlx5_wqe_init_inline_rma(
+      uint16_t wqe_idx, uint8_t opcode, uint32_t qpn, uint8_t fm_ce_se,
+      uintptr_t raddr, __be32 rkey,
+      uintptr_t laddr, __be32 lkey, uint32_t byte_count,
+      bool send_inline) {
+    // return braced-init-list to directly initialize the returned object
+    if (send_inline) {
+      return {wqe_idx, opcode, qpn, fm_ce_se, raddr, rkey, laddr, byte_count};
+    } else {
+      return {wqe_idx, opcode, qpn, fm_ce_se, raddr, rkey, laddr, lkey, byte_count};
+    }
+  }
+
+public:
+  // use gda_mlx5_wqe_init_inline_rma to construct either the inline or memory pointer RMA WQE
+  __device__ constexpr inline gda_mlx5_wqe(
+      uint16_t wqe_idx, uint8_t opcode, uint32_t qpn, uint8_t fm_ce_se,
+      uintptr_t raddr, __be32 rkey,
+      uintptr_t laddr, __be32 lkey, uint32_t byte_count,
+      bool send_inline)
+    : gda_mlx5_wqe{gda_mlx5_wqe_init_inline_rma(
+        wqe_idx, opcode, qpn, fm_ce_se,
+        raddr, rkey,
+        laddr, lkey, byte_count,
+        send_inline)} { }
+} __attribute__((__packed__)) __attribute__((__aligned__(64)));
+static_assert(sizeof(gda_mlx5_wqe) == sizeof(gda_mlx5_wqe_segment[4]),
+              "mlx5 WQEs have up to 4 segments");
+
+// WQE header is the first two 4-byte fields in the WQE control segment
+struct gda_mlx5_wqe_header {
+  __be32 opmod_idx_opcode;
+  __be32 qpn_ds;
+} __attribute__((__packed__)) __attribute__((__aligned__(8)));
+
+// doorbell value is WQE header
+union gda_mlx5_db_register {
+  uint64_t            val;
+  gda_mlx5_wqe_header wqe_header;
+
+  __device__ constexpr inline gda_mlx5_db_register(uint64_t val) : val{val} { }
+  __device__ constexpr inline gda_mlx5_db_register(const gda_mlx5_wqe_header& wqe_header)
+    : wqe_header{wqe_header} { }
+  __device__ constexpr inline gda_mlx5_db_register(__be32 opmod_idx_opcode, __be32 qpn_ds)
+    : val{(static_cast<uint64_t>(qpn_ds) << 32) | static_cast<uint64_t>(opmod_idx_opcode)} { }
+  __device__ constexpr inline gda_mlx5_db_register(const gda_mlx5_wqe_ctrl& ctrl)
+    : gda_mlx5_db_register{gda_mlx5_wqe_header{ctrl.opmod_idx_opcode, ctrl.qpn_ds}} { }
+  __device__ constexpr inline gda_mlx5_db_register(const gda_mlx5_wqe& wqe)
+    : gda_mlx5_db_register{wqe.ctrl} { }
+} __attribute__((__packed__)) __attribute__((__aligned__(8)));
+
+/* BlueFlame buffer size should technically be checked, but it seems to always be 256B
+ * BlueFlame buffer "must be written in chunks of DWORDs or multiple DWORDs"
+ * WQEs need to be aligned to WQEBB (64B), which implies that the BlueFlame buffer is as well?
+ * first 8 bytes is the doorbell register */
+union gda_mlx5_bf_buffer {
+  gda_mlx5_db_register db_reg;
+  uint8_t              data[256];
+  __be32               dword[64];
+} __attribute__((__packed__)) __attribute__((__aligned__(64)));
+
+/* BlueFlame buffers are paired into two halves that should be written alternately
+ * I think this only matters when using the BlueFlame mechanism, which requires Write Combining
+ * If just ringing the doorbell, we can write to the same half */
+struct gda_mlx5_doorbell {
+  gda_mlx5_bf_buffer bf[2];
+} __attribute__((__packed__)) __attribute__((__aligned__(64)));
+
+template <typename T>
+struct gda_mlx5_device_queue {
+  T* buf;
+  __be32* dbrec;
+  uint32_t lock;
+
+  __host__ inline gda_mlx5_device_queue(T* buf, __be32* dbrec)
+    : buf{buf}, dbrec{dbrec}, lock{0} { }
+
+  __host__ inline gda_mlx5_device_queue() : gda_mlx5_device_queue{nullptr, nullptr} { }
+};
+
+struct gda_mlx5_device_cq : public gda_mlx5_device_queue<mlx5_cqe64> {
+  // inherit constructors
+  using gda_mlx5_device_queue::gda_mlx5_device_queue;
+};
+
+struct gda_mlx5_device_sq : public gda_mlx5_device_queue<gda_mlx5_wqe> {
+//  uint64_t* db;
+  gda_mlx5_doorbell* db;
+  uint32_t bf_offset;
+  uint16_t depth;
+  uint16_t head;
+  uint16_t tail;
+
+#if 0
+  __device__ inline gda_mlx5_device_sq(T* buf, __be32* dbrec, uint64_t* db, uint16_t depth)
+    : gda_mlx5_device_queue{buf, dbrec}, db{db}, depth{depth}, head{0}, tail{0} { }
+#endif
+  __host__ inline gda_mlx5_device_sq(gda_mlx5_wqe* buf, __be32* dbrec,
+                                     gda_mlx5_doorbell* db, uint16_t depth)
+    : gda_mlx5_device_queue{buf, dbrec}, db{db}, bf_offset{0}, depth{depth}, head{0}, tail{0} { }
+
+  __host__ inline gda_mlx5_device_sq() : gda_mlx5_device_sq{nullptr, nullptr, nullptr, 0} { }
+
+  __device__ inline gda_mlx5_bf_buffer* swap_bf_buffer() {
+#if 0
+    uint32_t prior_offset = __hip_atomic_fetch_xor(&bf_offset, 0x1,
+                                                   __ATOMIC_ACQ_REL, __HIP_MEMORY_SCOPE_AGENT);
+    return &db->bf[prior_offset];
+#endif
+    uint32_t prior_offset = bf_offset;
+    bf_offset ^= 0x1;
+    return &db->bf[prior_offset];
+  }
+};
 
 struct mlx5dv_funcs_t {
   int (*init_obj)(struct mlx5dv_obj *obj, uint64_t obj_type);
 };
+
+} // namespace rocshmem
 
 #endif  //LIBRARY_SRC_GDA_MLX5_GDA_PROVIDER_HPP_

--- a/src/gda/mlx5/queue_pair_mlx5.cpp
+++ b/src/gda/mlx5/queue_pair_mlx5.cpp
@@ -30,307 +30,368 @@
 
 namespace rocshmem {
 
-__device__ void QueuePair::mlx5_ring_doorbell(uint64_t db_val, uint64_t my_sq_counter) {
-  *dbrec = byteswap<uint32_t>(my_sq_counter);
-  __atomic_signal_fence(__ATOMIC_SEQ_CST);
+__device__ static inline void amdgcn_s_wakeup() {
+  /* why doesn't __builtin_amdgcn_s_wakeup() exist?
+   * signals other wavefronts in the same workgroup to exit early from s_sleep */
+  asm volatile("s_wakeup");
+}
 
-  __hip_atomic_store(db.ptr, db_val, __ATOMIC_SEQ_CST, __HIP_MEMORY_SCOPE_SYSTEM);
-  uint64_t db_uint = __hip_atomic_load(&db.uint, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
-  db_uint ^= 0x100;
-  __hip_atomic_store(&db.uint, db_uint, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+__device__ static inline void acquire_lock(uint32_t *lock) {
+  /* acquire lock when 1 (locked) is exchanged with 0 (unlocked)
+   *
+   * the __ATOMIC_ACQUIRE load synchronizes with the __ATOMIC_RELEASE store in release_lock(),
+   * but not with the (implicit) __ATOMIC_RELAXED store part of the exchange
+   * this is fine, since we only need to ensure happens-before between the threads
+   * that released and acquired the lock, not between the different threads contending on the lock
+   * when they (eventually) acquire the lock, *then* they will synchronize */
+  while (__hip_atomic_exchange(lock, 1, __ATOMIC_ACQUIRE, __HIP_MEMORY_SCOPE_AGENT)) {
+    // sleep for 65-128 cycles so we don't hammer the memory
+    __builtin_amdgcn_s_sleep(2);
+  }
+}
+
+__device__ static inline void release_lock(uint32_t *lock) {
+  // release lock by storing 0 (unlocked)
+  __hip_atomic_store(lock, 0, __ATOMIC_RELEASE, __HIP_MEMORY_SCOPE_AGENT);
+#if 0
+  // wake up any other sleeping waves (in the same workgroup)
+  amdgcn_s_wakeup();
+#endif
+}
+
+__device__ static inline uint16_t mlx5_wqe_idx(const gda_mlx5_device_sq& sq, uint8_t lane_id) {
+  return sq.tail + lane_id;
+}
+
+__device__ void QueuePair::mlx5_ring_doorbell(uint16_t sq_wqebb_counter, const gda_mlx5_wqe& wqe) {
+#if 0
+  /* yes, the HCA is big-endian, so this looks wrong
+   * however, these are technically two 32-bit fields and they are already stored as BE
+   * so storing db_val from as LE will store the (BE swapped) opmod_idx_opcode field first
+   * and then the (BE swapped) qpn_ds field second, which is what we want */
+  uint64_t db_val = (static_cast<uint64_t>(wqe.ctrl.qpn_ds) << 32) |
+                     static_cast<uint64_t>(wqe.ctrl.opmod_idx_opcode);
+#endif
+  //gda_mlx5_db_register db_val{wqe.ctrl.opmod_idx_opcode, wqe.ctrl.qpn_ds};
+  gda_mlx5_db_register db_val{wqe};
+  __be32 be_sq_wqebb_counter = endian::to_be<uint32_t>(sq_wqebb_counter);
+
+#if 0
+  // get pointer to doorbell register in current BlueFlame buffer
+  uint64_t* db = __hip_atomic_load(&mlx5_sq.db, __ATOMIC_ACQUIRE, __HIP_MEMORY_SCOPE_AGENT);
+  do {
+    // swap BlueFlame buffers: each buffer is 256B, so the pointers are offset by 0x100
+    uintptr_t db_uintptr = reinterpret_cast<uintptr_t>(db);
+    db_uintptr ^= 0x100UL;
+    uint64_t* db_next = reinterpret_cast<uint64_t*>(db_uintptr);
+    // I don't think this cmpxch can ever fail since we hold the SQ lock, but let's be safe
+  } while (!__hip_atomic_compare_exchange_weak(&mlx5_db, &mlx5_sq.db, db_next,
+                                               __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE,
+                                               __HIP_MEMORY_SCOPE_AGENT));
+#endif
+#if 0
+  // get pointer to doorbell register in current BlueFlame buffer
+  uint64_t* db = mlx5_sq.db;
+  // swap BlueFlame buffers: each buffer is 256B, so the pointers are offset by 0x100
+  mlx5_sq.db = reinterpret_cast<uint64_t*>(reinterpret_cast<uintptr_t>(db) ^ 0x100UL);
+#endif
+  gda_mlx5_bf_buffer* bf = mlx5_sq.swap_bf_buffer();
+
+  // store sq_wqebb_counter to doorbell record
+  __hip_atomic_store(mlx5_sq.dbrec, be_sq_wqebb_counter, __ATOMIC_RELEASE, __HIP_MEMORY_SCOPE_SYSTEM);
+  // ring doorbell by storing first 8B of WQE to the doorbell register
+#if 0
+  __hip_atomic_store(db, db_val, __ATOMIC_RELEASE, __HIP_MEMORY_SCOPE_SYSTEM);
+#endif
+  __hip_atomic_store(&bf->db_reg, db_val, __ATOMIC_RELEASE, __HIP_MEMORY_SCOPE_SYSTEM);
+}
+
+__device__ void QueuePair::mlx5_check_cqe_error(const mlx5_cqe64* cqe) {
+  const mlx5_err_cqe* err_cqe = reinterpret_cast<const mlx5_err_cqe*>(cqe);
+  const char* cqe_syndrome_string = "";
+  uint8_t syndrome = 0x0;
+
+  uint8_t op_own = __hip_atomic_load(&cqe->op_own, __ATOMIC_ACQUIRE, __HIP_MEMORY_SCOPE_SYSTEM);
+  uint8_t owner = op_own & MLX5_CQE_OWNER_MASK;
+  uint8_t opcode = op_own >> 4;
+
+  switch (opcode) {
+  case MLX5_CQE_REQ:
+    // everything okay
+    return;
+  case MLX5_CQE_RESP_WR_IMM:
+  case MLX5_CQE_RESP_SEND:
+  case MLX5_CQE_RESP_SEND_IMM:
+  case MLX5_CQE_RESP_SEND_INV:
+    // (valid) responder completion?!
+    printf("CQ: unexpected responder completion (%x)\n", opcode);
+    break;
+  case MLX5_CQE_RESIZE_CQ:
+  case MLX5_CQE_NO_PACKET:
+    printf("CQ: unexpected completion type (%x)\n", opcode);
+    break;
+  case MLX5_CQE_SIG_ERR:
+    printf("CQ: unexpected signature error (%x)\n", opcode);
+    break;
+  case MLX5_CQE_REQ_ERR:
+    syndrome = __hip_atomic_load(&err_cqe->syndrome, __ATOMIC_ACQUIRE, __HIP_MEMORY_SCOPE_SYSTEM);
+    switch (syndrome) {
+    case MLX5_CQE_SYNDROME_LOCAL_LENGTH_ERR:
+      cqe_syndrome_string = "LOCAL_LENGTH_ERR";
+      break;
+    case MLX5_CQE_SYNDROME_LOCAL_QP_OP_ERR:
+      cqe_syndrome_string = "LOCAL_QP_OP_ERR";
+      break;
+    case MLX5_CQE_SYNDROME_LOCAL_PROT_ERR:
+      cqe_syndrome_string = "LOCAL_PROT_ERR";
+      break;
+    case MLX5_CQE_SYNDROME_WR_FLUSH_ERR:
+      cqe_syndrome_string = "WR_FLUSH_ERR";
+      break;
+    case MLX5_CQE_SYNDROME_MW_BIND_ERR:
+      cqe_syndrome_string = "MW_BIND_ERR";
+      break;
+    case MLX5_CQE_SYNDROME_BAD_RESP_ERR:
+      cqe_syndrome_string = "BAD_RESP_ERR";
+      break;
+    case MLX5_CQE_SYNDROME_LOCAL_ACCESS_ERR:
+      cqe_syndrome_string = "LOCAL_ACCESS_ERR";
+      break;
+    case MLX5_CQE_SYNDROME_REMOTE_INVAL_REQ_ERR:
+      cqe_syndrome_string = "REMOTE_INVAL_REQ_ERR";
+      break;
+    case MLX5_CQE_SYNDROME_REMOTE_ACCESS_ERR:
+      cqe_syndrome_string = "REMOTE_ACCESS_ERR";
+      break;
+    case MLX5_CQE_SYNDROME_REMOTE_OP_ERR:
+      cqe_syndrome_string = "REMOTE_OP_ERR";
+      break;
+    case MLX5_CQE_SYNDROME_TRANSPORT_RETRY_EXC_ERR:
+      cqe_syndrome_string = "TRANSPORT_RETRY_EXC_ERR";
+      break;
+    case MLX5_CQE_SYNDROME_RNR_RETRY_EXC_ERR:
+      cqe_syndrome_string = "RNR_RETRY_EXC_ERR";
+      break;
+    case MLX5_CQE_SYNDROME_REMOTE_ABORTED_ERR:
+      cqe_syndrome_string = "REMOTE_ABORTED_ERR";
+      break;
+    default:
+      cqe_syndrome_string = "unknown syndrome type";
+      break;
+    }
+    printf("CQ requester error: %s (%x)\n", cqe_syndrome_string, syndrome);
+    break;
+  case MLX5_CQE_RESP_ERR:
+    printf("CQ: unexpected responder error (%x)\n", opcode);
+    break;
+  case MLX5_CQE_INVALID:
+    printf("CQ: invalid completion (%x), check owner bit = %u?\n", opcode, owner);
+    break;
+  default:
+    printf("CQ: unknown completion type (%x)\n", opcode);
+    break;
+  }
+  abort();
+}
+
+__device__ void QueuePair::mlx5_poll_cq_until(uint16_t requested_available_slots) {
+  uint16_t consumed_slots;
+  uint16_t available_slots;
+
+  uint16_t sq_depth = mlx5_sq.depth;
+
+  // CQ lock (possibly) not needed with CQ collapsing
+  //acquire_lock(&mlx5_cq.lock);
+
+  do {
+    struct mlx5_cqe64* cqe = mlx5_cq.buf;
+
+#ifdef DEBUG
+    mlx5_check_cqe_error(cqe);
+#endif
+
+    /* Update the SQ head
+     * This param provides us the sq_wqebb_counter; all our WQEs are exactly one WQEBB (64B) */
+    __be16 be_wqe_counter = __hip_atomic_load(&cqe->wqe_counter, __ATOMIC_ACQUIRE, __HIP_MEMORY_SCOPE_SYSTEM);
+    uint16_t sq_head = endian::from_be(be_wqe_counter);
+    mlx5_sq.head = sq_head;
+
+    /* do we not need to hold the SQ lock here?
+     * what happens if one wavefront is in quiet() and another is is post_wqe_rma()?
+     * sq.tail can only get updated by another wavefront while this one is holding cq.lock if:
+     *   1. other thread was already holding sq.lock, and
+     *   2. other thread had already drained CQ until it had enough WQEs for the active lanes, and
+     *   3. other thread had not yet finished writing to the SQ and ringing the doorbell
+     * I think this is fine as long as post_wqe_rma stores to sq.tail before the doorbell ring
+     * maybe needs SEQ_CST?
+     *
+     * wavefront0       | wavefront1                   | HCA
+     * -----------------|------------------------------|-----------------------------
+     * store(sq.tail)   |                              |
+     * atomic_store(db) |                              |
+     *                  |                              | atomic_load(db)
+     *                  |                              | process WQ
+     *                  |                              | atomic_store(cqe.wqe_counter)
+     *                  | atomic_load(cqe.wqe_counter) |
+     *                  | load(sq.tail) [atomic?]      |
+     */
+    uint16_t sq_tail = __hip_atomic_load(&mlx5_sq.tail, __ATOMIC_ACQUIRE, __HIP_MEMORY_SCOPE_AGENT);
+
+    /* sq_tail > sq_head, except when sq_tail has wrapped around 0xFFFF and sq_head hasn't
+     * but sq_tail - sq_head is correct even when it wraps around
+     * in some marginal cases it's maybe possible to see consumed_slots > sq_depth,
+     * but in that case available_slots will be very large, > requested_available_slots,
+     * and the loop will continue for another iteration */
+    consumed_slots  = sq_tail - sq_head;
+    available_slots = sq_depth - consumed_slots;
+    // can put in __builtin_amdgcn_s_sleep(1) when fail?
+  } while (available_slots < requested_available_slots);
+
+  //release_lock(&mlx5_cq.lock);
 }
 
 __device__ void QueuePair::mlx5_quiet() {
-  constexpr size_t BROADCAST_SIZE = 1024 / WF_SIZE;
-  __shared__ uint64_t wqe_broadcast[BROADCAST_SIZE];
-  uint8_t wavefront_id = get_flat_block_id() / WF_SIZE;
-  wqe_broadcast[wavefront_id] = 0;
-
-  uint64_t activemask = get_active_lane_mask();
-  uint8_t num_active_lanes = get_active_lane_count(activemask);
-  uint8_t my_logical_lane_id = get_active_lane_num(activemask);
-  bool is_leader{my_logical_lane_id == 0};
-  const uint64_t leader_phys_lane_id = get_first_active_lane_id(activemask);
-
-  while (true) {
-    bool done{false};
-    uint64_t quiet_amount{0};
-    uint64_t wave_cq_consumer{0};
-    while (!done) {
-      uint64_t active = __hip_atomic_load(&quiet_active, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
-      uint64_t posted = __hip_atomic_load(&quiet_posted, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
-      uint64_t completed = __hip_atomic_load(&quiet_completed, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
-      if (!(posted - completed)) {
-        return;
-      }
-      int64_t quiet_val = posted - active;
-      if (quiet_val <= 0) {
-        continue;
-      }
-      quiet_amount = min(num_active_lanes, quiet_val);
-      if (is_leader) {
-        done = __hip_atomic_compare_exchange_strong(&quiet_active, &active, active + quiet_amount, __ATOMIC_RELAXED, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
-        if (done) {
-          wave_cq_consumer = __hip_atomic_fetch_add(&cq_consumer, quiet_amount, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
-        }
-      }
-      done = __shfl(done, leader_phys_lane_id);
-    }
-    wave_cq_consumer = __shfl(wave_cq_consumer, leader_phys_lane_id);
-    uint64_t my_cq_consumer = wave_cq_consumer + my_logical_lane_id;
-    uint64_t my_cq_index = my_cq_consumer % cq_cnt;
-
-    if (my_logical_lane_id < quiet_amount) {
-      volatile mlx5_cqe64 *cqe_entry = &cq_buf[my_cq_index];
-      uint16_t be_wqe_counter{0};
-      uint8_t op_own{0};
-      uint8_t owner_bit = (my_cq_consumer >> cq_log_cnt) & 1;
-      bool vote_failed{true};
-
-      while (vote_failed) {
-        op_own = *((volatile uint8_t*)&cqe_entry->op_own);
-        bool my_ownership_vote = (op_own & 1) == owner_bit;
-        bool my_opcode_vote = (op_own >> 4) != MLX5_CQE_INVALID;
-        uint64_t votes = __ballot(my_ownership_vote && my_opcode_vote);
-        vote_failed = __popcll(votes) < quiet_amount;
-        if (!vote_failed) {
-          be_wqe_counter = *((volatile uint16_t*)&cqe_entry->wqe_counter);
-        }
-      }
-
-      uint16_t wqe_counter = byteswap<uint16_t>(be_wqe_counter);
-      uint64_t wqe_id =  outstanding_wqes[wqe_counter];
-      __hip_atomic_fetch_max(&wqe_broadcast[wavefront_id], wqe_id, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_WORKGROUP);
-      uint8_t mlx5_invld_bits = MLX5_CQE_INVALID << 4 | owner_bit;
-      *((volatile uint8_t*)&cqe_entry->op_own) = mlx5_invld_bits;
-      __atomic_signal_fence(__ATOMIC_SEQ_CST);
-    }
-    if (is_leader) {
-      uint64_t completed {0};
-      do {
-        completed = __hip_atomic_load(&quiet_completed, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
-      } while (completed != wave_cq_consumer);
-
-      *cq_dbrec = byteswap<uint32_t>(wave_cq_consumer + quiet_amount);
-      __atomic_signal_fence(__ATOMIC_SEQ_CST);
-
-      uint64_t sunk_wqe_id = wqe_broadcast[wavefront_id];
-      __hip_atomic_fetch_max(&sq_sunk, sunk_wqe_id, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
-      __hip_atomic_fetch_add(&quiet_completed, quiet_amount, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
-    }
+  if (is_first_active_lane()) {
+    mlx5_poll_cq_until(mlx5_sq.depth);
   }
 }
 
-__device__ __forceinline__ void QueuePair::mlx5_wait_for_free_sq_slots(
-    uint64_t wave_sq_counter, uint8_t num_active_lanes) {
-  while (true) {
-    uint64_t db_touched = __hip_atomic_load(&sq_db_touched,
-                          __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
-
-    uint64_t sunk       = __hip_atomic_load(&sq_sunk,
-                          __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
-
-    int64_t num_active_sq_entries =
-        static_cast<int64_t>(db_touched) -
-        static_cast<int64_t>(sunk);
-
-    if (num_active_sq_entries < 0) {
-      continue;
-    }
-
-    uint64_t num_free_entries =
-        min(sq_wqe_cnt, cq_cnt) -
-        static_cast<uint64_t>(num_active_sq_entries);
-
-    uint64_t num_entries_until_wave_last_entry =
-        wave_sq_counter + num_active_lanes - db_touched;
-
-    if (num_free_entries > num_entries_until_wave_last_entry) {
-      break;
-    }
-
-    mlx5_quiet();
-  }
+__device__ void QueuePair::mlx5_quiet_single() {
+  mlx5_poll_cq_until(mlx5_sq.depth);
 }
 
-__device__ __forceinline__ void QueuePair::mlx5_build_rma_wqe(
-    uint64_t my_sq_counter, uint64_t my_sq_index, uintptr_t laddr,
-    uintptr_t raddr, int32_t size, uint8_t opcode) {
-  outstanding_wqes[my_sq_counter % OUTSTANDING_TABLE_SIZE] = my_sq_counter;
+// called with all active lanes communicating with the same PE, i.e. using the same SQ
+__device__ void QueuePair::mlx5_post_wqe_rma(int pe, int32_t length, uintptr_t laddr, uintptr_t raddr, uint8_t opcode) {
+  uint64_t active_lane_mask;
+  uint8_t active_lane_count;
+  uint8_t active_lane_id;
 
-  SegmentBuilder seg_build(my_sq_index, sq_buf);
+  active_lane_mask  = get_active_lane_mask();
+  active_lane_count = get_active_lane_count(active_lane_mask);
+  active_lane_id    = get_active_lane_num(active_lane_mask);
 
-  seg_build.update_ctrl_seg(my_sq_counter, opcode, 0, qp_num,
-                            MLX5_WQE_CTRL_CQ_UPDATE, 3, 0, 0);
-  seg_build.update_raddr_seg(raddr, rkey);
+  /* since the leader needs to write the first 8 bytes of the LAST WQE to the doorbell register,
+   * it's easier if the LAST thread is the leader; does this have any performance implications? */
+  bool is_leader = (active_lane_id == active_lane_count - 1);
 
-  if (size <= inline_threshold && opcode == gda_op_rdma_write) {
-    seg_build.update_inl_data_seg(reinterpret_cast<const void*>(laddr), size);
-  } else {
-    seg_build.update_data_seg(laddr, size, lkey);
-  }
-}
-
-__device__ __forceinline__ void QueuePair::mlx5_wait_for_db_touched_eq(
-    uint64_t target_sq_counter) {
-  uint64_t db_touched {0};
-  do {
-    db_touched = __hip_atomic_load(&sq_db_touched,
-                 __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
-  } while (db_touched != target_sq_counter);
-}
-
-__device__ __forceinline__ void QueuePair::mlx5_ring_doorbell(
-    uint64_t wave_sq_counter, uint8_t num_wqes) {
-  mlx5_wait_for_db_touched_eq(wave_sq_counter);
-
-  uint8_t *base_ptr = reinterpret_cast<uint8_t*>(sq_buf);
-  uint64_t* ctrl_wqe_8B_for_db =
-      reinterpret_cast<uint64_t*>(&base_ptr[64 *
-        ((wave_sq_counter + num_wqes - 1) % sq_wqe_cnt)]);
-
-  mlx5_ring_doorbell(*ctrl_wqe_8B_for_db, wave_sq_counter + num_wqes);
-
-  __hip_atomic_fetch_add(&quiet_posted, num_wqes,
-    __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
-
-  __hip_atomic_store(&sq_db_touched, wave_sq_counter + num_wqes,
-    __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
-}
-
-__device__ void QueuePair::mlx5_post_wqe_rma(int32_t size, uintptr_t laddr,
-    uintptr_t raddr, uint8_t opcode) {
-  uint64_t activemask          = get_active_lane_mask();
-  uint8_t  num_active_lanes    = get_active_lane_count(activemask);
-  uint8_t  my_logical_lane_id  = get_active_lane_num(activemask);
-  bool     is_leader           = {my_logical_lane_id == 0};
-  uint64_t leader_phys_lane_id = get_first_active_lane_id(activemask);
-
-  uint8_t  num_wqes        = num_active_lanes;
-  uint64_t wave_sq_counter = 0;
-  uint64_t my_sq_counter   = 0;
-  uint64_t my_sq_index     = 0;
-
-  // 1. Leader allocates SQ entries for the whole wave
   if (is_leader) {
-    wave_sq_counter = __hip_atomic_fetch_add(&sq_posted, num_wqes,
-                      __ATOMIC_SEQ_CST, __HIP_MEMORY_SCOPE_AGENT);
+    // get SQ lock
+    acquire_lock(&mlx5_sq.lock);
+    // poll until we have enough WQEBB for all active lanes
+    mlx5_poll_cq_until(active_lane_count);
   }
-  wave_sq_counter = __shfl(wave_sq_counter, leader_phys_lane_id);
-  my_sq_counter   = wave_sq_counter + my_logical_lane_id;
-  my_sq_index     = my_sq_counter % sq_wqe_cnt;
 
-  // 2. Wait for SQ space for the whole wave
-  mlx5_wait_for_free_sq_slots(wave_sq_counter, num_active_lanes);
+  // wqe_idx is the logical WQE id that wraps at 0xFFFF, sq_idx is the index into the actual SQ
+  uint16_t wqe_idx = mlx5_wqe_idx(mlx5_sq, active_lane_id);
+  uint16_t sq_idx = wqe_idx % mlx5_sq.depth;
 
-  // 3. Build the WQE for this lane
-  mlx5_build_rma_wqe(my_sq_counter, my_sq_index, laddr, raddr, size, opcode);
+  // construct the WQE on the stack
+  bool send_inline = gda_mlx5_wqe_rma::can_inline(opcode, length, inline_threshold);
 
-  __atomic_signal_fence(__ATOMIC_SEQ_CST);
+  gda_mlx5_wqe wqe{wqe_idx, opcode, qp_num, MLX5_WQE_CTRL_CQ_UPDATE,
+                   raddr, rkey, laddr, lkey, static_cast<uint32_t>(length), send_inline};
 
-  // 4. Leader rings doorbell for the wave
+  // copy to SQ
+  mlx5_sq.buf[sq_idx] = wqe;
+
   if (is_leader) {
-    mlx5_ring_doorbell(wave_sq_counter, num_wqes);
+    // increment tail counter
+    mlx5_sq.tail += active_lane_count;
+    // we are the last thread in the wavefront, so we have the last WQE posted
+    mlx5_ring_doorbell(mlx5_sq.tail, wqe);
+    // release SQ lock
+    release_lock(&mlx5_sq.lock);
   }
 }
 
-__device__ __forceinline__ uint64_t*
-QueuePair::mlx5_allocate_wave_fetching_atomic_buffer(
-    uint64_t wave_sq_counter, bool is_leader,
-    uint64_t leader_phys_lane_id) {
-  uint64_t* wave_fetch_atomic{nullptr};
-  if (is_leader) {
-    mlx5_wait_for_db_touched_eq(wave_sq_counter);
+// called with all active lanes communicating with different PEs, i.e. using different SQs
+__device__ void QueuePair::mlx5_post_wqe_rma_single(int pe, int32_t length, uintptr_t laddr,
+                                                    uintptr_t raddr, uint8_t opcode) {
+  // get SQ lock
+  acquire_lock(&mlx5_sq.lock);
+  // poll until we have enough space for at least one WQE
+  mlx5_poll_cq_until(1);
 
-    auto res = fetching_atomic_freelist->pop_front();
-    while (!res.success) {
-      res = fetching_atomic_freelist->pop_front();
-    }
-    wave_fetch_atomic = res.value;
-  }
-  wave_fetch_atomic = (uint64_t*)__shfl((uint64_t)wave_fetch_atomic,
-                        leader_phys_lane_id);
-  return wave_fetch_atomic;
+  // wqe_idx is the logical WQE id that wraps at 0xFFFF, sq_idx is the index into the actual SQ
+  uint16_t wqe_idx = mlx5_sq.tail;
+  uint16_t sq_idx = wqe_idx % mlx5_sq.depth;
+
+  // construct the WQE on the stack
+  bool send_inline = gda_mlx5_wqe_rma::can_inline(opcode, length, inline_threshold);
+  gda_mlx5_wqe wqe{wqe_idx, opcode, qp_num, MLX5_WQE_CTRL_CQ_UPDATE,
+                   raddr, rkey, laddr, lkey, static_cast<uint32_t>(length), send_inline};
+
+  // copy to SQ
+  mlx5_sq.buf[sq_idx] = wqe;
+
+  // increment tail counter
+  mlx5_sq.tail += 1;
+  // ring doorbell for this WQE (note: need to check this for correctness)
+  mlx5_ring_doorbell(mlx5_sq.tail, wqe);
+  // release SQ lock
+  release_lock(&mlx5_sq.lock);
 }
 
-__device__ __forceinline__ void QueuePair::mlx5_build_amo_wqe(
-    uint64_t my_sq_counter, uint64_t my_sq_index, uintptr_t raddr,
-    uint8_t opcode, int64_t atomic_data, int64_t atomic_cmp, bool fetching,
-    uint64_t *wave_fetch_atomic) {
-  outstanding_wqes[my_sq_counter % OUTSTANDING_TABLE_SIZE] = my_sq_counter;
+// called with all active lanes communicating with the same PE, i.e. using the same SQ
+__device__ uint64_t QueuePair::mlx5_post_wqe_amo(int pe, int32_t length, uintptr_t raddr, uint8_t opcode,
+                                                 int64_t atomic_data, int64_t atomic_cmp, bool fetching) {
+  uint64_t active_lane_mask;
+  uint8_t active_lane_count;
+  uint8_t active_lane_id;
 
-  SegmentBuilder seg_build(my_sq_index, sq_buf);
-  seg_build.update_ctrl_seg(my_sq_counter, opcode, 0, qp_num,
-                            MLX5_WQE_CTRL_CQ_UPDATE, 4, 0, 0);
-  seg_build.update_raddr_seg(raddr, rkey);
-  seg_build.update_atomic_seg(atomic_data, atomic_cmp);
+  active_lane_mask  = get_active_lane_mask();
+  active_lane_count = get_active_lane_count(active_lane_mask);
+  active_lane_id    = get_active_lane_num(active_lane_mask);
 
+  /* since the leader needs to write the first 8 bytes of the LAST WQE to the doorbell register,
+   * it's easier if the LAST thread is the leader; does this have any performance implications? */
+  bool is_leader = (active_lane_id == active_lane_count - 1);
+
+  if (is_leader) {
+    // get SQ lock
+    acquire_lock(&mlx5_sq.lock);
+    // poll until we have enough WQEBB for all active lanes
+    mlx5_poll_cq_until(active_lane_count);
+  }
+
+  uint64_t* atomic_laddr = nonfetching_atomic;
+  uint32_t atomic_lkey = nonfetching_atomic_lkey;
   if (fetching) {
-    seg_build.update_data_seg(reinterpret_cast<uintptr_t>(wave_fetch_atomic), 8, fetching_atomic_lkey);
-  } else {
-    seg_build.update_data_seg(reinterpret_cast<uintptr_t>(nonfetching_atomic), 8, nonfetching_atomic_lkey);
+    uint32_t atomic_idx = (fetching_atomic_idx + active_lane_id) % FETCHING_ATOMIC_CNT;
+    atomic_laddr = &fetching_atomic[atomic_idx];
+    atomic_lkey = fetching_atomic_lkey;
   }
-}
 
-__device__ uint64_t QueuePair::mlx5_post_wqe_amo(int32_t size,
-    uintptr_t raddr, uint8_t opcode, int64_t atomic_data,
-    int64_t atomic_cmp, bool fetching) {
-  uint64_t activemask          = get_active_lane_mask();
-  uint8_t  num_active_lanes    = get_active_lane_count(activemask);
-  uint8_t  my_logical_lane_id  = get_active_lane_num(activemask);
-  bool     is_leader           = {my_logical_lane_id == 0};
-  uint64_t leader_phys_lane_id = get_first_active_lane_id(activemask);
+  // wqe_idx is the logical WQE id that wraps at 0xFFFF, sq_idx is the index into the actual SQ
+  uint16_t wqe_idx = mlx5_wqe_idx(mlx5_sq, active_lane_id);
+  uint16_t sq_idx = wqe_idx % mlx5_sq.depth;
 
-  uint8_t  num_wqes        = num_active_lanes;
-  uint64_t wave_sq_counter = 0;
-  uint64_t my_sq_counter   = 0;
-  uint64_t my_sq_index     = 0;
+  // construct the WQE on the stack
+  gda_mlx5_wqe wqe{wqe_idx, opcode, qp_num, MLX5_WQE_CTRL_CQ_UPDATE,
+                   raddr, rkey,
+                   static_cast<uint64_t>(atomic_data), static_cast<uint64_t>(atomic_cmp),
+                   reinterpret_cast<uintptr_t>(atomic_laddr), atomic_lkey};
 
-  // 1. Leader allocates SQ entries for the whole wave
+  // copy to SQ
+  mlx5_sq.buf[sq_idx] = wqe;
+
   if (is_leader) {
-    wave_sq_counter = __hip_atomic_fetch_add(&sq_posted, num_wqes,
-                      __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
-  }
-  wave_sq_counter = __shfl(wave_sq_counter, leader_phys_lane_id);
-  my_sq_counter   = wave_sq_counter + my_logical_lane_id;
-  my_sq_index     = my_sq_counter % sq_wqe_cnt;
-
-  // 2. Wait for SQ space for the whole wave
-  mlx5_wait_for_free_sq_slots(wave_sq_counter, num_active_lanes);
-
-  uint64_t* wave_fetch_atomic{nullptr};
-  if (fetching) {
-    wave_fetch_atomic = mlx5_allocate_wave_fetching_atomic_buffer(
-        wave_sq_counter,
-        is_leader,
-        leader_phys_lane_id);
+    // increment tail and fetching atomic counters
+    mlx5_sq.tail += active_lane_count;
+    if (fetching) {
+      fetching_atomic_idx += active_lane_count;
+    }
+    // we are the last thread in the wavefront, so we have the last WQE posted
+    mlx5_ring_doorbell(mlx5_sq.tail, wqe);
+    // release SQ lock
+    release_lock(&mlx5_sq.lock);
   }
 
-  // 3. Build the WQE for this lane
-  mlx5_build_amo_wqe(my_sq_counter, my_sq_index, raddr, opcode,
-                     atomic_data, atomic_cmp, fetching,
-                     wave_fetch_atomic + my_logical_lane_id);
-
-  __atomic_signal_fence(__ATOMIC_SEQ_CST);
-
-  // 4. Leader rings doorbell for the wave
-  if (is_leader) {
-    mlx5_ring_doorbell(wave_sq_counter, num_wqes);
-  }
-
-  // 5. Fetch result if requested
-  uint64_t ret{0};
   if (fetching) {
     mlx5_quiet();
-    ret = wave_fetch_atomic[my_logical_lane_id];
-
-    __atomic_signal_fence(__ATOMIC_SEQ_CST);
-
-    if (is_leader) {
-      fetching_atomic_freelist->push_back(wave_fetch_atomic);
-    }
   }
-  return ret;
+
+  return fetching ? *atomic_laddr : 0;
 }
 
 }  // namespace rocshmem

--- a/src/gda/queue_pair.cpp
+++ b/src/gda/queue_pair.cpp
@@ -157,7 +157,7 @@ __device__ void QueuePair::post_wqe_rma_mt(int pe, int32_t size, uintptr_t laddr
   switch (gda_provider_) {
 #if defined(GDA_MLX5)
   case GDAProvider::MLX5:
-    mlx5_post_wqe_rma(size, laddr, raddr, opcode);
+    mlx5_post_wqe_rma(pe, size, laddr, raddr, opcode);
     return;
 #endif
 #if defined(GDA_BNXT)
@@ -191,7 +191,7 @@ __device__ uint64_t QueuePair::post_wqe_amo(int pe, int32_t size, uintptr_t radd
   switch (gda_provider_) {
 #if defined(GDA_MLX5)
   case GDAProvider::MLX5:
-    return mlx5_post_wqe_amo(size, raddr, opcode, atomic_data, atomic_cmp, fetching);
+    return mlx5_post_wqe_amo(pe, size, raddr, opcode, atomic_data, atomic_cmp, fetching);
 #endif
 #if defined(GDA_BNXT)
   case GDAProvider::BNXT:

--- a/src/gda/queue_pair.hpp
+++ b/src/gda/queue_pair.hpp
@@ -180,40 +180,11 @@ class QueuePair {
   __device__ __attribute__((noinline)) void post_wqe_rma_mt(int pe, int32_t size, uintptr_t laddr, uintptr_t raddr, uint8_t opcode);
 
 #if defined(GDA_MLX5)
-  __device__ __forceinline__ void
-  mlx5_wait_for_free_sq_slots(uint64_t wave_sq_counter,
-      uint8_t num_active_lanes);
-
-  __device__ __forceinline__ void
-  mlx5_wait_for_db_touched_eq(uint64_t target_sq_counter);
-
-  __device__ __forceinline__ void
-  mlx5_build_rma_wqe(uint64_t my_sq_counter, uint64_t my_sq_index,
-      uintptr_t laddr, uintptr_t raddr, int32_t size, uint8_t opcode);
-
-  __device__ __forceinline__ void
-  mlx5_build_amo_wqe(uint64_t my_sq_counter, uint64_t my_sq_index,
-      uintptr_t raddr, uint8_t opcode, int64_t atomic_data,
-      int64_t atomic_cmp, bool fetching, uint64_t *wave_fetch_atomic);
-
-  __device__ __forceinline__ uint64_t*
-  mlx5_allocate_wave_fetching_atomic_buffer(uint64_t wave_sq_counter,
-      bool is_leader, uint64_t leader_phys_lane_id);
-
-  __device__ __forceinline__ void
-  mlx5_ring_doorbell(uint64_t wave_sq_counter, uint8_t num_wqes);
-
-  __device__ uint64_t
-  mlx5_post_wqe_amo(int32_t size, uintptr_t raddr, uint8_t opcode,
-      int64_t atomic_data, int64_t atomic_cmp, bool fetch);
-
-  __device__ void
-  mlx5_post_wqe_rma(int32_t size, uintptr_t laddr,
-      uintptr_t raddr, uint8_t opcode);
-
-  __device__ void
-  mlx5_quiet();
-
+  __device__ uint64_t mlx5_post_wqe_amo(int pe, int32_t size, uintptr_t raddr, uint8_t opcode, int64_t atomic_data, int64_t atomic_cmp, bool fetch);
+  __device__ void mlx5_post_wqe_rma(int pe, int32_t size, uintptr_t laddr, uintptr_t raddr, uint8_t opcode);
+  __device__ void mlx5_post_wqe_rma_single(int pe, int32_t size, uintptr_t laddr, uintptr_t raddr, uint8_t opcode);
+  __device__ void mlx5_quiet();
+  __device__ void mlx5_quiet_single();
 #endif
 #if defined(GDA_BNXT)
 
@@ -241,7 +212,7 @@ class QueuePair {
    * @param[in] db_val Doorbell value is written by method.
    */
 #if defined(GDA_MLX5)
-  __device__ void mlx5_ring_doorbell(uint64_t db_val, uint64_t my_sq_counter);
+  __device__ void mlx5_ring_doorbell(uint16_t sq_wqebb_counter, const gda_mlx5_wqe& wqe);
 #endif
 #if defined(GDA_BNXT)
   __device__ void bnxt_ring_doorbell(uint32_t slot_idx);
@@ -264,6 +235,12 @@ class QueuePair {
 
   /* GDAProvider::MLX5 START */
 
+  gda_mlx5_device_cq mlx5_cq;
+  gda_mlx5_device_sq mlx5_sq;
+
+  __device__ void mlx5_poll_cq_until(uint16_t requested_available_slots);
+  __device__ void mlx5_check_cqe_error(const mlx5_cqe64* cqe);
+#if 0
   db_reg_t db{};
 
   uint64_t cq_consumer{0};
@@ -322,6 +299,7 @@ class QueuePair {
 
   static constexpr size_t OUTSTANDING_TABLE_SIZE = 65536;
   uint64_t outstanding_wqes[OUTSTANDING_TABLE_SIZE]{0};
+#endif /* 0 */
 
   /* GDAProvider::MLX5 END */
 


### PR DESCRIPTION
## Motivation

CQ collapsing has shown significant benefits for bnxt and ionic, we need to examine its use in mlx5.

AIROCSHMEM-5

## Technical Details

* The prior design inherently assumes that all CQEs will be observed: the number of observed CQEs is compared to the number of posted WQEs to determine SQ capacity. For performance, multiple threads per wavefront are used to poll the CQ.
* CQ collapsing will practically guarantee that some CQEs will be missed—you only observe the most recent CQE, with prior CQEs being overwritten. Only a single thread should be used to poll the CQ, since there's only a single CQE that needs to be polled. The prior design is thus not compatible with CQ collapsing.
* This PR replaces the QueuePair implementation with one based off the bnxt code. The code is massively simplified and now has comments explaining its behavior.
* In the future we will determine how to more closely merge the bnxt and mlx5 implementations to reduce the amount of duplicate code. This will also entail determining whether and how we can remove the current SQ lock and replace it by a lockless implementation, which is one feature that gets lost by utilizing the new design.
* Depends on PRs:
  * #368
  * #369
  * #373

## Test Plan

- [ ] Functional tests
- [ ] Microbenchmarks
- [ ] DeepEP

## Test Result

N/A, not yet completed
