### PR TITLE
Enable new a2a (pr 334) on ionic as well

### DIFF
--- a/src/gda/context_gda_tmpl_device.hpp
+++ b/src/gda/context_gda_tmpl_device.hpp
@@ -605,7 +605,8 @@ __device__ void GDAContext::internal_broadcast(T *dst, const T *src, int nelems,
 template <typename T>
 __device__ void GDAContext::alltoall(rocshmem_team_t team, T *dst,
                                      const T *src, int nelems) {
-  if (gda_provider_ == GDAProvider::BNXT) {
+  if (gda_provider_ == GDAProvider::BNXT ||
+      gda_provider_ == GDAProvider::IONIC) {
     alltoall_linear_thread_puts(team, dst, src, nelems);
   } else {
     alltoall_linear(team, dst, src, nelems);

--- a/src/gda/queue_pair.cpp
+++ b/src/gda/queue_pair.cpp
@@ -178,7 +178,7 @@ __device__ void QueuePair::post_wqe_rma_single(int32_t size, uintptr_t *laddr, u
 #endif
 #if defined(GDA_IONIC)
   case GDAProvider::IONIC:
-    return ionic_post_wqe_rma(0 /*unused*/, size, laddr, raddr, opcode, Collectivity::THREAD);
+    return ionic_post_wqe_rma(0 /*pe (unused)*/, size, laddr, raddr, opcode, Collectivity::THREAD);
 #endif
   case GDAProvider::MLX5:
   default:

--- a/src/gda/queue_pair.cpp
+++ b/src/gda/queue_pair.cpp
@@ -176,7 +176,10 @@ __device__ void QueuePair::post_wqe_rma_single(int32_t size, uintptr_t *laddr, u
   case GDAProvider::BNXT:
     return bnxt_post_wqe_rma_single(size, laddr, raddr, opcode, ring_db);
 #endif
+#if defined(GDA_IONIC)
   case GDAProvider::IONIC:
+    return ionic_post_wqe_rma(0 /*unused*/, size, laddr, raddr, opcode, Collectivity::THREAD);
+#endif
   case GDAProvider::MLX5:
   default:
     assert(false /* invalid nic provider */);
@@ -212,8 +215,11 @@ __device__ uint64_t QueuePair::post_wqe_amo_single(uintptr_t *raddr, uint8_t opc
   case GDAProvider::BNXT:
     return bnxt_post_wqe_amo_single(raddr, opcode, atomic_data, atomic_cmp, fetching);
 #endif
-  case GDAProvider::MLX5:
+#if defined(GDA_IONIC)
   case GDAProvider::IONIC:
+    return ionic_post_wqe_amo(0 /*unused*/, 8 /*only 8 implemented */, raddr, opcode, atomic_data, atomic_cmp, fetching);
+#endif
+  case GDAProvider::MLX5:
   default:
     assert(false /* invalid nic provider */);
     return 0;
@@ -253,8 +259,12 @@ __device__ void QueuePair::quiet_single() {
     bnxt_quiet_single();
     return;
 #endif
-  case GDAProvider::MLX5:
+#if defined(GDA_IONIC)
   case GDAProvider::IONIC:
+    ionic_quiet();
+    return;
+#endif
+  case GDAProvider::MLX5:
   default:
     assert(false /* invalid nic provider */);
   }

--- a/src/gda/queue_pair.cpp
+++ b/src/gda/queue_pair.cpp
@@ -217,7 +217,7 @@ __device__ uint64_t QueuePair::post_wqe_amo_single(uintptr_t *raddr, uint8_t opc
 #endif
 #if defined(GDA_IONIC)
   case GDAProvider::IONIC:
-    return ionic_post_wqe_amo(0 /*unused*/, 8 /*only 8 implemented */, raddr, opcode, atomic_data, atomic_cmp, fetching);
+    return ionic_post_wqe_amo(0 /*pe (unused)*/, 8 /*size_bytes (only 8-byte atomics implemented)*/, raddr, opcode, atomic_data, atomic_cmp, fetching);
 #endif
   case GDAProvider::MLX5:
   default:


### PR DESCRIPTION
## Motivation

Use the all2all optimized in pr #334 when using ionic-gda

## Technical Details

Remap the _single qp operations to the normal ones, as the ionic ops can safely do that.

## Test Plan

* [x] Ran on ionic 8 EP (1 node)
* [x] Ran on ionic 16 EP (2 nodes)

