### PR TITLE
Fix driver.sh script for system where neither amd-smi or rocm-smi are found

### DIFF
--- a/scripts/functional_tests/driver.sh
+++ b/scripts/functional_tests/driver.sh
@@ -133,6 +133,7 @@ ExecTest() {
   then
     NUM_GPUS=${NUM_GPUS:-$(rocm-smi --showserial | grep GPU | wc -l)}
   fi
+  NUM_GPUS=${NUM_GPUS:-0}
   NUM_GPUS=$(($NUM_GPUS > 0? $NUM_GPUS: 8))
 
   TEST_NUM=${TEST_NUMBERS[$TEST_NAME]}


### PR DESCRIPTION
## Motivation

ci/driver.sh would fail on systems where amd-smi and rocm-smi are not found.

## Technical Details

set the 'autodetect' value to 0 if neither exec found to collapse the behavior with exe found but no gpu found on the headnode. 

## Test plan

ci passes
