### PR TITLE
[Bugfix] GDA/bnxt: release SQ lock before return

### DIFF
--- a/src/gda/bnxt/queue_pair_bnxt.cpp
+++ b/src/gda/bnxt/queue_pair_bnxt.cpp
@@ -434,12 +434,12 @@ __device__ uint64_t QueuePair::bnxt_post_wqe_amo_single(uintptr_t raddr, uint8_t
 
   bnxt_ring_doorbell(sq.tail);
 
+  release_lock(&sq.lock);
+
   if (fetching) {
     quiet();
     return fetching_atomic[atomic_idx];
   }
-
-  release_lock(&sq.lock);
 
   return 0;
 }


### PR DESCRIPTION
bnxt_post_wqe_amo_single with fetching = true would return before releasing the send queue lock, resulting in a deadlock. Release the send queue lock before returning from the function.