### PR TITLE
disable the putmem_signal_on_stream test on RO conduit

### DIFF
--- a/scripts/functional_tests/driver.sh
+++ b/scripts/functional_tests/driver.sh
@@ -373,7 +373,7 @@ TestAMO() {
   ExecTest  "amo_add"          2       32           128
 }
 
-TestSigOps() {
+TestSigOpsRO() {
   ##############################################################################
   #       | Name             | Ranks | Workgroups | Threads | Max Message Size #
   ##############################################################################
@@ -394,8 +394,12 @@ TestSigOps() {
   ExecTest  "wavesignalfetch"  2       1            32
   ExecTest  "wavesignalfetch"  2       1            64
 
-  ExecTest  "putmem_signal_on_stream" 2  1          1         1048576
   ExecTest  "signal_wait_until_on_stream" 2  1      1
+}
+
+TestSigOps() {
+  TestSigOpsRO
+  ExecTest  "putmem_signal_on_stream" 2  1          1         1048576
 }
 
 TestColl() {
@@ -709,7 +713,7 @@ case $TEST in
   *"all-ro")
     TestRMAPut
     TestAMORO
-    TestSigOps
+    TestSigOpsRO
     TestColl
     TestOther
     ;;


### PR DESCRIPTION

## Motivation

The putmem_signal_on_stream test  fails in about 50% of the cases with the RO conduit. Will revisit later why it fails, but RO is at the moment lower priority, so disabling the test for now.  Created a JIRA ticket to track the issue.


## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
