### PR TITLE
Remove bnxt_*_single APIs and use get_same_qp_lane_mask() from IONIC

### DIFF
--- a/src/gda/bnxt/queue_pair_bnxt.cpp
+++ b/src/gda/bnxt/queue_pair_bnxt.cpp
@@ -201,16 +201,12 @@ __device__ void QueuePair::bnxt_quiet() {
   uint64_t active_lane_mask;
   uint8_t active_lane_id;
 
-  active_lane_mask  = get_active_lane_mask();
+  active_lane_mask  = get_same_qp_lane_mask();
   active_lane_id    = get_active_lane_num(active_lane_mask);
 
   if (0 == active_lane_id) {
     bnxt_poll_cq_until(bnxt_sq.depth);
   }
-}
-
-__device__ void QueuePair::bnxt_quiet_single() {
-  bnxt_poll_cq_until(bnxt_sq.depth);
 }
 
 __device__ void QueuePair::bnxt_write_rma_wqe(uintptr_t raddr, uintptr_t laddr, int32_t length, uint8_t opcode) {
@@ -283,7 +279,7 @@ __device__ void QueuePair::bnxt_post_wqe_rma(int pe, int32_t length, uintptr_t l
   uint8_t active_lane_count;
   uint8_t active_lane_id;
 
-  active_lane_mask  = get_active_lane_mask();
+  active_lane_mask  = get_same_qp_lane_mask();
   active_lane_count = get_active_lane_count(active_lane_mask);
   active_lane_id    = get_active_lane_num(active_lane_mask);
 
@@ -304,22 +300,6 @@ __device__ void QueuePair::bnxt_post_wqe_rma(int pe, int32_t length, uintptr_t l
   if (0 == active_lane_id) {
     release_lock(&bnxt_sq.lock);
   }
-}
-
-__device__ void QueuePair::bnxt_post_wqe_rma_single(int32_t length, uintptr_t laddr,
-                                                    uintptr_t raddr, uint8_t opcode,
-                                                    bool ring_db) {
-
-  acquire_lock(&bnxt_sq.lock);
-
-  /* Write WQE to SQ */
-  bnxt_write_rma_wqe(raddr, laddr, length, opcode);
-
-  if (ring_db) {
-    bnxt_ring_doorbell(bnxt_sq.tail);
-  }
-
-  release_lock(&bnxt_sq.lock);
 }
 
 __device__ uint32_t QueuePair::bnxt_write_amo_wqe(uintptr_t raddr, uint8_t opcode,
@@ -393,7 +373,7 @@ __device__ uint64_t QueuePair::bnxt_post_wqe_amo(uintptr_t raddr, uint8_t opcode
   uint8_t active_lane_id;
   uint32_t atomic_idx = 0;
 
-  active_lane_mask  = get_active_lane_mask();
+  active_lane_mask  = get_same_qp_lane_mask();
   active_lane_count = get_active_lane_count(active_lane_mask);
   active_lane_id    = get_active_lane_num(active_lane_mask);
 
@@ -413,28 +393,6 @@ __device__ uint64_t QueuePair::bnxt_post_wqe_amo(uintptr_t raddr, uint8_t opcode
   if (0 == active_lane_id) {
     release_lock(&bnxt_sq.lock);
   }
-
-  if (fetching) {
-    quiet();
-    return fetching_atomic[atomic_idx];
-  }
-
-  return 0;
-}
-
-__device__ uint64_t QueuePair::bnxt_post_wqe_amo_single(uintptr_t raddr, uint8_t opcode,
-                                                        int64_t atomic_data, int64_t atomic_cmp,
-                                                        bool fetching) {
-  uint32_t atomic_idx = 0;
-
-  acquire_lock(&bnxt_sq.lock);
-
-  /* Write WQE to SQ */
-  atomic_idx = bnxt_write_amo_wqe(raddr, opcode, atomic_data, atomic_cmp, fetching);
-
-  bnxt_ring_doorbell(bnxt_sq.tail);
-
-  release_lock(&bnxt_sq.lock);
 
   if (fetching) {
     quiet();

--- a/src/gda/context_gda_device.cpp
+++ b/src/gda/context_gda_device.cpp
@@ -148,10 +148,6 @@ __device__ void GDAContext::pe_quiet(size_t pe) {
   qps[pe].quiet();
 }
 
-__device__ void GDAContext::pe_quiet_single(size_t pe) {
-  qps[pe].quiet_single();
-}
-
 __device__ void *GDAContext::shmem_ptr(const void *dest, int pe) {
   void *ret = nullptr;
   int local_pe{-1};

--- a/src/gda/context_gda_device.hpp
+++ b/src/gda/context_gda_device.hpp
@@ -63,7 +63,6 @@ class GDAContext : public Context {
   __device__ void quiet_wave();
 
   __device__ void pe_quiet(size_t pe);
-  __device__ void pe_quiet_single(size_t pe);
 
   __device__ void *shmem_ptr(const void *dest, int pe);
 

--- a/src/gda/context_gda_tmpl_device.hpp
+++ b/src/gda/context_gda_tmpl_device.hpp
@@ -661,10 +661,10 @@ __device__ void GDAContext::alltoall_linear_thread_puts(rocshmem_team_t team, T 
   for (int j = tid; j < pe_size; j+= step_size) {
     int dest_pe = team_obj->get_pe_in_world(j);
     uint64_t base_heap_offset = base_heap[dest_pe] - base_heap[my_pe];
-    qps[dest_pe].put_nbi_single(reinterpret_cast<char*>(&dst[my_pe_in_team * nelems]) + base_heap_offset,
+    qps[dest_pe].put_nbi(reinterpret_cast<char*>(&dst[my_pe_in_team * nelems]) + base_heap_offset,
                                 &src[j * nelems], nelems * sizeof(T), false);
-    qps[dest_pe].atomic_nofetch_single(reinterpret_cast<char *>(&pSync[alltoall_pSync_offset + my_pe_in_team]) + base_heap_offset,
-                                       1);
+    qps[dest_pe].atomic_nofetch(reinterpret_cast<char *>(&pSync[alltoall_pSync_offset + my_pe_in_team]) + base_heap_offset,
+                                1, -1, -1);
   }
 
   // wait until everyone has obtained their designated data
@@ -674,7 +674,7 @@ __device__ void GDAContext::alltoall_linear_thread_puts(rocshmem_team_t team, T 
     volatile long *vol_ivars = &pSync[alltoall_pSync_offset + dest_pe];
     while (uncached_load(vol_ivars) != 1) { }
 
-    pe_quiet_single(dest_pe);
+    pe_quiet(dest_pe);
 
     pSync[alltoall_pSync_offset + dest_pe] = ROCSHMEM_SYNC_VALUE;
   }

--- a/src/gda/ionic/queue_pair_ionic.cpp
+++ b/src/gda/ionic/queue_pair_ionic.cpp
@@ -29,14 +29,6 @@
 
 namespace rocshmem {
 
-__device__ uint64_t QueuePair::get_same_qp_lane_mask() {
-  uint64_t active = get_active_lane_mask();
-  uintptr_t this_qp = reinterpret_cast<uintptr_t>(this);
-  // Bitmask of lanes in this warp whose value == this_qp
-  uint64_t same_qp_mask = __match_any_sync(active, this_qp);
-  return same_qp_mask;
-}
-
 __device__ uint32_t QueuePair::reserve_sq(uint64_t activemask, uint32_t num_wqes) {
   uint32_t my_sq_prod = 0;
 

--- a/src/gda/queue_pair.cpp
+++ b/src/gda/queue_pair.cpp
@@ -144,7 +144,7 @@ __device__ void QueuePair::post_wqe_rma(int pe, int32_t size, uintptr_t laddr, u
 #if defined(GDA_MLX5)
   case GDAProvider::MLX5:
     post_wqe_rma_turn(pe, size, laddr, raddr, opcode, cy);
-    return
+    return;
 #endif
   default:
     return;

--- a/src/gda/queue_pair.cpp
+++ b/src/gda/queue_pair.cpp
@@ -118,6 +118,14 @@ QueuePair::~QueuePair() {
   allocator.deallocate((void*)fetching_atomic_freelist);
 }
 
+__device__ uint64_t QueuePair::get_same_qp_lane_mask() {
+  uint64_t active = get_active_lane_mask();
+  uintptr_t this_qp = reinterpret_cast<uintptr_t>(this);
+  // Bitmask of lanes in this warp whose value == this_qp
+  uint64_t same_qp_mask = __match_any_sync(active, this_qp);
+  return same_qp_mask;
+}
+
 /******************************************************************************
  ************************ PROVIDER-SPECIFIC HELPERS ***************************
  *****************************************************************************/
@@ -128,11 +136,22 @@ __device__ void QueuePair::post_wqe_rma(int pe, int32_t size, uintptr_t laddr, u
     ionic_post_wqe_rma(pe, size, laddr, raddr, opcode, cy);
     return;
 #endif
-  default:
+#if defined(GDA_BNXT)
+  case GDAProvider::BNXT:
+    bnxt_post_wqe_rma(pe, size, laddr, raddr, opcode);
+    return;
+#endif
+#if defined(GDA_MLX5)
+  case GDAProvider::MLX5:
     post_wqe_rma_turn(pe, size, laddr, raddr, opcode, cy);
+    return
+#endif
+  default:
+    return;
   }
 }
 
+#if defined(GDA_MLX5)
 __device__ void QueuePair::post_wqe_rma_turn(int pe, int32_t size, uintptr_t laddr, uintptr_t raddr, uint8_t opcode, Collectivity cy) {
   if (cy == THREAD) {
     bool need_turn {true};
@@ -141,50 +160,18 @@ __device__ void QueuePair::post_wqe_rma_turn(int pe, int32_t size, uintptr_t lad
       uint8_t lane = __ffsll((unsigned long long)turns) - 1;
       int pe_turn = __shfl(pe, lane);
       if (pe_turn == pe) {
-        post_wqe_rma_mt(pe, size, laddr, raddr, opcode);
+        mlx5_post_wqe_rma(size, laddr, raddr, opcode);
         need_turn = false;
       }
       turns = __ballot(need_turn);
     }
   } else {
     if (is_thread_zero_in_wave()) {
-      post_wqe_rma_mt(pe, size, laddr, raddr, opcode);
+      mlx5_post_wqe_rma(size, laddr, raddr, opcode);
     }
   }
 }
-
-__device__ void QueuePair::post_wqe_rma_mt(int pe, int32_t size, uintptr_t laddr, uintptr_t raddr, uint8_t opcode) {
-  switch (gda_provider_) {
-#if defined(GDA_MLX5)
-  case GDAProvider::MLX5:
-    mlx5_post_wqe_rma(size, laddr, raddr, opcode);
-    return;
 #endif
-#if defined(GDA_BNXT)
-  case GDAProvider::BNXT:
-    bnxt_post_wqe_rma(pe, size, laddr, raddr, opcode);
-    return;
-#endif
-  default:
-    assert(false /* invalid nic provider */);
-  }
-}
-
-__device__ void QueuePair::post_wqe_rma_single(int32_t size, uintptr_t laddr, uintptr_t raddr, uint8_t opcode, bool ring_db) {
-  switch (gda_provider_) {
-#if defined(GDA_BNXT)
-  case GDAProvider::BNXT:
-    return bnxt_post_wqe_rma_single(size, laddr, raddr, opcode, ring_db);
-#endif
-#if defined(GDA_IONIC)
-  case GDAProvider::IONIC:
-    return ionic_post_wqe_rma(0 /*pe (unused)*/, size, laddr, raddr, opcode, Collectivity::THREAD);
-#endif
-  case GDAProvider::MLX5:
-  default:
-    assert(false /* invalid nic provider */);
-  }
-}
 
 __device__ uint64_t QueuePair::post_wqe_amo(int pe, int32_t size, uintptr_t raddr, uint8_t opcode,
                                             int64_t atomic_data, int64_t atomic_cmp, bool fetching) {
@@ -207,25 +194,6 @@ __device__ uint64_t QueuePair::post_wqe_amo(int pe, int32_t size, uintptr_t radd
   }
 }
 
-__device__ uint64_t QueuePair::post_wqe_amo_single(uintptr_t raddr, uint8_t opcode,
-                                                   int64_t atomic_data, int64_t atomic_cmp,
-                                                   bool fetching) {
-  switch (gda_provider_) {
-#if defined(GDA_BNXT)
-  case GDAProvider::BNXT:
-    return bnxt_post_wqe_amo_single(raddr, opcode, atomic_data, atomic_cmp, fetching);
-#endif
-#if defined(GDA_IONIC)
-  case GDAProvider::IONIC:
-    return ionic_post_wqe_amo(0 /*pe (unused)*/, 8 /*size_bytes (only 8-byte atomics implemented)*/, raddr, opcode, atomic_data, atomic_cmp, fetching);
-#endif
-  case GDAProvider::MLX5:
-  default:
-    assert(false /* invalid nic provider */);
-    return 0;
-  }
-}
-
 __device__ void QueuePair::quiet(Collectivity cy) {
   switch (gda_provider_) {
 #if defined(GDA_MLX5)
@@ -237,9 +205,7 @@ __device__ void QueuePair::quiet(Collectivity cy) {
 #endif
 #if defined(GDA_BNXT)
   case GDAProvider::BNXT:
-    if (cy == THREAD || is_thread_zero_in_wave()) {
-      bnxt_quiet();
-    }
+    bnxt_quiet();
     return;
 #endif
 #if defined(GDA_IONIC)
@@ -247,24 +213,6 @@ __device__ void QueuePair::quiet(Collectivity cy) {
     ionic_quiet();
     return;
 #endif
-  default:
-    assert(false /* invalid nic provider */);
-  }
-}
-
-__device__ void QueuePair::quiet_single() {
-  switch (gda_provider_) {
-#if defined(GDA_BNXT)
-  case GDAProvider::BNXT:
-    bnxt_quiet_single();
-    return;
-#endif
-#if defined(GDA_IONIC)
-  case GDAProvider::IONIC:
-    ionic_quiet();
-    return;
-#endif
-  case GDAProvider::MLX5:
   default:
     assert(false /* invalid nic provider */);
   }
@@ -277,12 +225,6 @@ __device__ void QueuePair::put_nbi(void *dest, const void *source, size_t nelems
   uintptr_t src = reinterpret_cast<uintptr_t>(source);
   uintptr_t dst = reinterpret_cast<uintptr_t>(dest);
   post_wqe_rma(pe, nelems, src, dst, gda_op_rdma_write, cy);
-}
-
-__device__ void QueuePair::put_nbi_single(void *dest, const void *source, size_t nelems, bool ring_db) {
-  uintptr_t src = reinterpret_cast<uintptr_t>(source);
-  uintptr_t dst = reinterpret_cast<uintptr_t>(dest);
-  post_wqe_rma_single(nelems, src, dst, gda_op_rdma_write, ring_db);
 }
 
 __device__ void QueuePair::get_nbi(void *dest, const void *source, size_t nelems, int pe, Collectivity cy) {
@@ -309,11 +251,6 @@ __device__ int64_t QueuePair::atomic_fetch(void *dest, int64_t atomic_data, int6
 __device__ void QueuePair::atomic_nofetch(void *dest, int64_t atomic_data, int64_t atomic_cmp, int pe) {
   uintptr_t dst = reinterpret_cast<uintptr_t>(dest);
   post_wqe_amo(pe, sizeof(int64_t), dst, gda_op_atomic_fa, atomic_data, atomic_cmp, false);
-}
-
-__device__ void QueuePair::atomic_nofetch_single(void *dest, int64_t value) {
-  uintptr_t dst = reinterpret_cast<uintptr_t>(dest);
-  post_wqe_amo_single(dst, gda_op_atomic_fa, value, 0, false);
 }
 
 }  // namespace rocshmem

--- a/src/gda/queue_pair.hpp
+++ b/src/gda/queue_pair.hpp
@@ -78,8 +78,6 @@ class QueuePair {
    */
   __device__ void put_nbi(void *dest, const void *source, size_t nelems, int pe, Collectivity cy = THREAD);
 
-  __device__ void put_nbi_single(void *dest, const void *source, size_t nelems, bool ring_db);
-
   /**
    * @brief Create and enqueue a non-blocking get work queue entry (wqe).
    *
@@ -94,7 +92,6 @@ class QueuePair {
    * @brief Empty all completions from the completion queue.
    */
   __device__ void quiet(Collectivity cy = THREAD);
-  __device__ void quiet_single();
 
   /**
    * @brief Create and enqueue an atomic fetch work queue entry (wqe).
@@ -117,8 +114,6 @@ class QueuePair {
    * @param[in] pe Destination processing element of data transmission.
    */
   __device__ void atomic_nofetch(void *dest, int64_t value, int64_t cond, int pe);
-
-  __device__ void atomic_nofetch_single(void *dest, int64_t value);
 
   /**
    * @brief Create and enqueue an atomic cas work queue entry (wqe).
@@ -158,12 +153,6 @@ class QueuePair {
    */
   __device__ __attribute__((noinline)) uint64_t post_wqe_amo(int pe, int32_t size, uintptr_t raddr, uint8_t opcode, int64_t atomic_data, int64_t atomic_cmp, bool fetch);
 
-  __device__ __attribute__((noinline)) uint64_t post_wqe_amo_single(uintptr_t raddr,
-                                                                    uint8_t opcode,
-                                                                    int64_t atomic_data,
-                                                                    int64_t atomic_cmp,
-                                                                    bool fetching);
-
   /**
    * @brief Helper method to build work requests for the send queue.
    *
@@ -174,10 +163,6 @@ class QueuePair {
    * @param[in] opcode Operation to be performed.
    */
   __device__ __attribute__((noinline)) void post_wqe_rma(int pe, int32_t size, uintptr_t laddr, uintptr_t raddr, uint8_t opcode, Collectivity cy);
-  __device__ __attribute__((noinline)) void post_wqe_rma_turn(int pe, int32_t size, uintptr_t laddr, uintptr_t raddr, uint8_t opcode, Collectivity cy);
-
-  __device__ __attribute__((noinline)) void post_wqe_rma_single(int32_t size, uintptr_t laddr, uintptr_t raddr, uint8_t opcode, bool ring_db);
-  __device__ __attribute__((noinline)) void post_wqe_rma_mt(int pe, int32_t size, uintptr_t laddr, uintptr_t raddr, uint8_t opcode);
 
 #if defined(GDA_MLX5)
   __device__ __forceinline__ void
@@ -214,20 +199,19 @@ class QueuePair {
   __device__ void
   mlx5_quiet();
 
+  __device__ __attribute__((noinline)) void post_wqe_rma_turn(int pe, int32_t size, uintptr_t laddr, uintptr_t raddr, uint8_t opcode, Collectivity cy);
+
 #endif
 #if defined(GDA_BNXT)
 
   __device__ void bnxt_write_rma_wqe(uintptr_t raddr, uintptr_t laddr, int32_t length, uint8_t opcode);
   __device__ uint32_t bnxt_write_amo_wqe(uintptr_t raddr, uint8_t opcode, int64_t atomic_data, int64_t atomic_cmp, bool fetching);
 
-  __device__ uint64_t bnxt_post_wqe_amo_single(uintptr_t raddr, uint8_t opcode, int64_t atomic_data, int64_t atomic_cmp, bool fetching);
   __device__ uint64_t bnxt_post_wqe_amo(uintptr_t raddr, uint8_t opcode, int64_t atomic_data, int64_t atomic_cmp, bool fetching);
 
   __device__ void bnxt_post_wqe_rma(int pe, int32_t size, uintptr_t laddr, uintptr_t raddr, uint8_t opcode);
 
-  __device__ void bnxt_post_wqe_rma_single(int32_t size, uintptr_t laddr, uintptr_t raddr, uint8_t opcode, bool ring_db);
   __device__ void bnxt_quiet();
-  __device__ void bnxt_quiet_single();
 #endif
 #if defined(GDA_IONIC)
   __device__ uint64_t ionic_post_wqe_amo(int pe, int32_t size, uintptr_t raddr, uint8_t opcode, int64_t atomic_data, int64_t atomic_cmp, bool fetch);


### PR DESCRIPTION
## Motivation

Prior to #367, using `get_same_qp_lane_mask()` would be around 4us more expensive than `get_active_lane_mask()` when trying to use this optimization in the bnxt code path

After that PR, the overhead was reduce to around 0.5us, this results in there little benefit in having the `*_single` APIs

## Test Plan

I plan to test all NICs to ensure I didn't break anything else as a part of this refactor

- [x] bnxt functional tests
- [x] mlx5 functional tests
- [ ] ionic functional tests
