### PR TITLE
Fix __match_any_sync on ROCm 6.x

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -214,6 +214,11 @@ if (NOT BUILD_TESTS_ONLY)
       -fgpu-rdc
   )
 
+  if(${ROCM_MAJOR_VERSION} LESS 7)
+    # ROCm 6.x requires us to explicitly enable warp sync builtins
+    target_compile_definitions(${PROJECT_NAME} PRIVATE HIP_ENABLE_WARP_SYNC_BUILTINS=1)
+  endif()
+
   #############################################################################
   # INSTALL
   #############################################################################


### PR DESCRIPTION
## Motivation

PR #367 introduced `__match_any_sync` into the rocSHMEM code base. 

This function is not available in some older versions of rocm without enabling it

```
/home/amd/ytemucin/rocSHMEM/src/gda/ionic/queue_pair_ionic.cpp:36:27: error: use of undeclared identifier '__match_any_sync'                                                                                          
   36 |   uint64_t same_qp_mask = __match_any_sync(active, this_qp);     
```