### PR TITLE
add additional runtime checks and gfx1201 fix

### DIFF
--- a/src/bootstrap/bootstrap.cpp
+++ b/src/bootstrap/bootstrap.cpp
@@ -37,19 +37,6 @@
 
 namespace rocshmem {
 
-static void setFilesLimit() {
-  rlimit filesLimit;
-  if (getrlimit(RLIMIT_NOFILE, &filesLimit) != 0) {
-    DPRINTF("getrlimit failed\n");
-    return;
-  }
-  filesLimit.rlim_cur = filesLimit.rlim_max;
-  if (setrlimit(RLIMIT_NOFILE, &filesLimit) != 0) {
-    DPRINTF("setrlimit failed\n");
-    return;
-  }
-}
-
 /* Socket Interface Selection type */
 enum bootstrapInterface_t { findSubnetIf = -1, dontCareIf = -2 };
 
@@ -391,7 +378,6 @@ void TcpBootstrap::Impl::bootstrapRoot() {
 
   std::memset(rankAddresses.data(), 0, sizeof(SocketAddress) * nRanks_);
   std::memset(rankAddressesRoot.data(), 0, sizeof(SocketAddress) * nRanks_);
-  setFilesLimit();
 
   DPRINTF("BEGIN bootstrapRoot\n");
   /* Receive addresses from all ranks */

--- a/src/ipc/backend_ipc.cpp
+++ b/src/ipc/backend_ipc.cpp
@@ -108,6 +108,13 @@ IPCBackend::IPCBackend(TcpBootstrap *bootstrap):  Backend(bootstrap) {
 void IPCBackend::init() {
   ROCSHMEM_HOST_CTX_DEFAULT.ctx_opaque = default_host_ctx.get();
 
+  const char *arch_name = get_arch_name(hip_dev_id);
+  if (strncmp(arch_name, "gfx1201", strlen("gfx1201")) == 0) {
+    fine_grained_allocator_ = new HIPAllocatorFinegrained();
+  } else {
+    fine_grained_allocator_ = new HIPDefaultFinegrainedAllocator();
+  }
+
   setup_team_world();
 
   setup_wrk_sync_buffers();
@@ -137,6 +144,14 @@ IPCBackend::~IPCBackend() {
   CHECK_HIP(hipFree(team_world));
 
   CHECK_HIP(hipFree(ctx_array));
+  if (fine_grained_allocator_) {
+    const char *arch_name = get_arch_name(hip_dev_id);
+    if (strncmp(arch_name, "gfx1201", strlen("gfx1201")) == 0) {
+      delete static_cast<HIPAllocatorFinegrained *>(fine_grained_allocator_);
+    } else {
+      delete static_cast<HIPDefaultFinegrainedAllocator *>(fine_grained_allocator_);
+    }
+  }
 }
 
 void IPCBackend::setup_ctxs() {
@@ -364,8 +379,8 @@ void IPCBackend::setup_wrk_sync_buffers() {
    * Allocate a buffer of size wrk_sync_pool_size_, using fine-grained
    * memory allocator
   */
-  fine_grained_allocator_.allocate((void**)&wrk_sync_pool_,
-                                   wrk_sync_pool_size_);
+  fine_grained_allocator_->allocate((void**)&wrk_sync_pool_,
+                                    wrk_sync_pool_size_);
   assert(wrk_sync_pool_);
   wrk_sync_pool_top_ = wrk_sync_pool_;
 
@@ -396,7 +411,7 @@ void IPCBackend::setup_wrk_sync_buffers() {
    * Allocate device-side fine grained memory to hold IPC addresses of
    * work/sync buffers
    */
-  fine_grained_allocator_.allocate(
+  fine_grained_allocator_->allocate(
     reinterpret_cast<void**>(&wrk_sync_pool_bases_),
     num_pes * sizeof(char*));
   assert(wrk_sync_pool_bases_);
@@ -423,8 +438,8 @@ void IPCBackend::cleanup_wrk_sync_buffer() {
       CHECK_HIP(hipIpcCloseMemHandle(wrk_sync_pool_bases_[i]));
     }
   }
-  fine_grained_allocator_.deallocate(wrk_sync_pool_bases_);
-  fine_grained_allocator_.deallocate(wrk_sync_pool_);
+  fine_grained_allocator_->deallocate(wrk_sync_pool_bases_);
+  fine_grained_allocator_->deallocate(wrk_sync_pool_);
 }
 
 void IPCBackend::setup_fence_buffer() {

--- a/src/ipc/backend_ipc.hpp
+++ b/src/ipc/backend_ipc.hpp
@@ -258,7 +258,7 @@ class IPCBackend : public Backend {
   /**
    * Fine grained memory allocator for buffers used in collectives Routines
    */
-  HIPDefaultFinegrainedAllocator fine_grained_allocator_ {};
+  MemoryAllocator *fine_grained_allocator_{nullptr};
 
   /**
    * @brief Collective routines work/sync buffer size

--- a/src/ipc/context_ipc_device.cpp
+++ b/src/ipc/context_ipc_device.cpp
@@ -178,6 +178,7 @@ __device__ void IPCContext::internal_putmem_wg(void *dest, const void *source,
   uint64_t L_offset = reinterpret_cast<char *>(dest) - wrk_sync_pool_bases_[my_pe];
   memcpy_wg(wrk_sync_pool_bases_[pe] + L_offset, const_cast<void *>(source), nelems);
   __syncthreads();
+  ipcImpl_.ipcFence();
 }
 
 __device__ void IPCContext::internal_getmem_wg(void *dest, const void *source,

--- a/src/ipc/context_ipc_tmpl_device.hpp
+++ b/src/ipc/context_ipc_tmpl_device.hpp
@@ -174,7 +174,7 @@ __device__ void IPCContext::internal_direct_allreduce(
   int stride = team_obj->tinfo_wrt_world->stride;
   int PE_start = team_obj->tinfo_wrt_world->pe_start;
   int PE_size = team_obj->tinfo_wrt_world->size;
-  long *pSync = team_obj->barrier_pSync;
+  long *pSync = team_obj->reduce_pSync;
   T *pWrk = reinterpret_cast<T *>(team_obj->pWrk);
 
   int finish = PE_start + stride * PE_size;
@@ -195,7 +195,7 @@ __device__ void IPCContext::internal_direct_allreduce(
                     nelems * sizeof(T), i);
 
       if (is_thread_zero_in_block()) {
-        fence();
+        fence(i);
         internal_putmem(&pSync[pe], &flag_val, sizeof(*pSync), i);
       }
     }
@@ -223,7 +223,6 @@ __device__ void IPCContext::internal_direct_allreduce(
   for (int i = wg_id; i < num_pes; i += wg_size) {
     pSync[i] = ROCSHMEM_SYNC_VALUE;
   }
-  threadfence_system();
   __syncthreads();
 }
 
@@ -291,7 +290,7 @@ __device__ void IPCContext::internal_ring_allreduce(
   int stride = team_obj->tinfo_wrt_world->stride;
   int PE_start = team_obj->tinfo_wrt_world->pe_start;
   int PE_size = team_obj->tinfo_wrt_world->size;
-  long *pSync = team_obj->barrier_pSync;
+  long *pSync = team_obj->reduce_pSync;
   T *pWrk = reinterpret_cast<T *>(team_obj->pWrk);
   int my_pe_in_team = team_obj->my_pe;
 
@@ -321,13 +320,9 @@ __device__ void IPCContext::internal_ring_allreduce(
                     chunk_size * sizeof(T), send_pe);
 
       if (is_thread_zero_in_block()) {
-        fence();
-
         wait_val = seg + 100;
+        fence(send_pe);
         internal_putmem(&pSync[iter], &wait_val, sizeof(*pSync), send_pe);
-#if defined(__gfx90a__)
-        __threadfence_system();
-#endif /* __gfx90a__ */
         wait_until(&pSync[iter], ROCSHMEM_CMP_EQ, wait_val);
       }
       __syncthreads();
@@ -343,12 +338,9 @@ __device__ void IPCContext::internal_ring_allreduce(
                     chunk_size * sizeof(T), send_pe);
 
       if (is_thread_zero_in_block()) {
-        fence();
-        wait_val = seg + 100;
+        wait_val = seg + 10;
+        fence(send_pe);
         internal_putmem(&pSync[iter], &wait_val, sizeof(*pSync), send_pe);
-#if defined(__gfx90a__)
-        __threadfence_system();
-#endif /* __gfx90a__ */
         wait_until(&pSync[iter], ROCSHMEM_CMP_EQ, wait_val);
       }
       __syncthreads();
@@ -418,6 +410,7 @@ __device__ int IPCContext::reduce(rocshmem_team_t team, T *dest,
       return ROCSHMEM_ERROR;
     }
   }
+  barrier_wg(team);
   return ROCSHMEM_SUCCESS;
 }
 

--- a/src/rocshmem.cpp
+++ b/src/rocshmem.cpp
@@ -60,6 +60,8 @@
 #include <random>
 #include <cassert>
 #include <unistd.h>
+#include <sys/time.h>
+#include <sys/resource.h>
 
 namespace rocshmem {
 
@@ -115,6 +117,18 @@ static BackendType select_backend_type() {
   return BackendType::IPC_BACKEND;
 }
 #endif
+static void setFilesLimit() {
+  rlimit filesLimit;
+  if (getrlimit(RLIMIT_NOFILE, &filesLimit) != 0) {
+    DPRINTF("getrlimit failed\n");
+    return;
+  }
+  filesLimit.rlim_cur = filesLimit.rlim_max;
+  if (setrlimit(RLIMIT_NOFILE, &filesLimit) != 0) {
+    DPRINTF("setrlimit failed\n");
+    return;
+  }
+}
 
 [[maybe_unused]] __host__ void inline library_init(MPI_Comm comm) {
   assert(!backend);
@@ -126,6 +140,7 @@ static BackendType select_backend_type() {
     abort();
   }
 
+  setFilesLimit();
   rocm_init();
 
   int ret;
@@ -241,6 +256,7 @@ static BackendType select_backend_type() {
     abort();
   }
 
+  setFilesLimit();
   rocm_init();
 
 #if defined(USE_GDA) && defined(USE_RO) && defined(USE_IPC)

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -52,11 +52,21 @@ static void device_properties_init(void) {
 
   device_prop_t prop;
   hipDeviceProp_t hipprop;
+  int has_large_bar = 0;
   for (int i=0; i<numDevices; i++) {
     CHECK_HIP(hipGetDeviceProperties(&hipprop, i));
     prop.warpSize = hipprop.warpSize;
     prop.maxThreadsPerBlock = hipprop.maxThreadsPerBlock;
+    std::snprintf(prop.gcnArchName, sizeof(prop.gcnArchName), "%s",
+                  hipprop.gcnArchName);
     device_properties.push_back(prop);
+
+    CHECK_HIP(hipDeviceGetAttribute (&has_large_bar, hipDeviceAttributeIsLargeBar, i));
+    if (has_large_bar == 0) {
+      // Large BAR required for IPC operations
+      printf("Warning: Large BAR support is not enabled on device %d. "
+             "This will impact IPC functionality on some systems.\n", i);
+    }
   }
 }
 hsa_status_t rocm_hsa_amd_memory_pool_callback(

--- a/src/util.hpp
+++ b/src/util.hpp
@@ -152,6 +152,7 @@ extern const int gpu_clock_freq_mhz;
 typedef struct device_prop {
   int warpSize;
   int maxThreadsPerBlock;
+  char gcnArchName[256];
 } device_prop_t;
 
 extern std::vector<device_prop_t> device_properties;
@@ -164,6 +165,11 @@ static int get_threads_per_block(int device_id) {
 static int get_wf_size(int device_id) {
   assert(device_properties.size() > device_id);
   return device_properties[device_id].warpSize;
+}
+
+static const char* get_arch_name(int device_id) {
+  assert(device_properties.size() > device_id);
+  return device_properties[device_id].gcnArchName;
 }
 
 /* Device-side internal functions */

--- a/tests/functional_tests/team_reduction_tester.cpp
+++ b/tests/functional_tests/team_reduction_tester.cpp
@@ -83,7 +83,7 @@ __global__ void TeamReductionTest(int loop, int skip, long long int *start_time,
   __shared__ rocshmem_ctx_t ctx;
   int wg_id = get_flat_grid_id();
 
-  rocshmem_wg_ctx_create(ctx_type, &ctx);
+  rocshmem_wg_team_create_ctx(team, ctx_type, &ctx);
 
   int n_pes = rocshmem_ctx_n_pes(ctx);
 


### PR DESCRIPTION
add additional runtime checks and gfx1201 fix

For AIROCSHMEM-237

This commit contains three fixes:
 - increase the max. number of files at the beginning of the run to the max. allowed by the system
 - check for large BAR support. WE don not abort if its not available, but print a warning.
 - for gfx1201, do not use uncached memory at the moment.

(cherry picked from commit d21abd36efc1ef57ad2c391cca8fcae313fc359e)

fix allreduce tester (https://github.com/ROCm/rocSHMEM/pull/385)
- use the reduce_psync buffers for synchronization in allreduce, not the
  barrier_psync.
- execute a wwg barrier after the allreduce operation. After internal
  discussion it was determined that it is required for correctness.

(cherry picked from commit https://github.com/ROCm/rocSHMEM/commit/6f512e92a57719764c4ef5b071212c90e26c3ebe)

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
